### PR TITLE
Give context on where the build-tools live

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Build tools for standard makefile
 
+**These build tools live at https://github.com/drud/build-tools**. If you are viewing this README in any other repository, it's important to know that modifications should **never** be made directly, and instead should be made to the base repository and pulled in via the subtree merge instructions below.
+
 These tools add standard components (sub-makefiles and build scripts) as well as example starters for the Makefile and circle.yml.
 
 ## Add build-tools to a Makefile


### PR DESCRIPTION
When viewing this README in other repositories, such as drud-go, the context for the subtree merge instructions are not immediately clear. This is handled via examples and headers in other files, but since the README is likely the first thing people would look at, we should make sure to explicitly call it out there as well.