### PR TITLE
Add new build-tools update technique - build_update.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,20 @@
 
 These tools add standard components (sub-makefiles and build scripts) as well as example starters for the Makefile and circle.yml.
 
-## Add build-tools to a Makefile
+## Add build-tools for the first time to a Makefile
 
-```
-git remote add -f build-tools git@github.com:drud/build-tools.git
-git merge -s ours --allow-unrelated-histories build-tools/master
-git read-tree --prefix=build-tools -u build-tools/master
-git commit -m "Added build-tools for standard makefile as subtree"
-```
+Download the [build_updates.sh](https://github.com/drud/build-tools/blob/master/build_updates.sh) script and run it in the directory where the build-tools should be added.
+
+Alternately, just download the latest release from https://github.com/drud/build-tools/releases/latest, extract it, rename it to build-tools, and commit the result.
+
 
 ## Update build-tools directory from this repository using subtree merge
 
+Run the build_update.sh script in the build-tools directory:
+
 ```
-# If there is not a build-tools remote, add it
-git remote add -f build-tools git@github.com:drud/build-tools.git
-# Fetch/merge current build-tools (pull doesn't work if set to branch.autosetuprebase=always)
-git fetch build-tools
-git merge -s subtree build-tools/master
+cd build-tools
+./build_update.sh
 ```
 
 ## Set up a Makefile to begin with
@@ -40,6 +37,8 @@ Using this base will allow you to build with standard targets like build, test, 
 
 ```
 make 
+make linux
+make darwin
 make test
 make container
 make push

--- a/build_update.sh
+++ b/build_update.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Update (or install) build-tools to latest release on https://github.com/drud/build-tools/releases/latest
+
+set -e
+
+base_url=$(curl -s -I https://github.com/drud/build-tools/releases/latest | awk '/^Location/ {gsub(/[\n\r]/,"",$2);  printf "%s", $2}')
+tag=${base_url##*/}
+
+tarball_url="https://github.com/drud/build-tools/archive/$tag.tar.gz"
+internal_name=build-tools-$tag
+local_file=/tmp/$internal_name.tgz
+
+# If there is a current build-tools, get permission and remove
+if [ -d ../build-tools ]; then
+	echo "OK to replace current build-tools at $PWD?"
+	read -p "Replace build-tools with latest version? y/N" -n 1 -r
+	echo
+	if ! [[ $REPLY =~ ^[Yy]$ ]]
+	then
+	  echo "Exiting"
+	  exit 1
+	fi
+	cd ..
+	git rm -r build-tools
+# If no current build-tools, prompt, get permission to add
+else
+	echo "OK to add current build-tools at $PWD/build-tools?"
+	read -p "Add build-tools with latest version? y/N" -n 1 -r
+	echo
+	if ! [[ $REPLY =~ ^[Yy]$ ]]
+	then
+	  echo "Exiting"
+	  exit 1
+	fi
+fi
+
+
+wget -q -O $local_file $tarball_url
+tar -xf $local_file
+mv $internal_name build-tools
+git add build-tools
+echo "Updated build-tools to $tag
+
+$base_url" | git commit -F -

--- a/build_update.sh
+++ b/build_update.sh
@@ -11,8 +11,6 @@ tarball_url="https://github.com/drud/build-tools/archive/$tag.tar.gz"
 internal_name=build-tools-$tag
 local_file=/tmp/$internal_name.tgz
 
-set -x
-
 # If there is a current build-tools, get permission and remove
 if [ "${PWD##*/}" = "build-tools" ]; then
 	echo "OK to replace current build-tools at $PWD?"

--- a/build_update.sh
+++ b/build_update.sh
@@ -11,8 +11,10 @@ tarball_url="https://github.com/drud/build-tools/archive/$tag.tar.gz"
 internal_name=build-tools-$tag
 local_file=/tmp/$internal_name.tgz
 
+set -x
+
 # If there is a current build-tools, get permission and remove
-if [ -d ../build-tools ]; then
+if [ "${PWD##*/}" = "build-tools" ]; then
 	echo "OK to replace current build-tools at $PWD?"
 	read -p "Replace build-tools with latest version? y/N" -n 1 -r
 	echo
@@ -22,7 +24,6 @@ if [ -d ../build-tools ]; then
 	  exit 1
 	fi
 	cd ..
-	git rm -r build-tools
 # If no current build-tools, prompt, get permission to add
 else
 	echo "OK to add current build-tools at $PWD/build-tools?"
@@ -38,7 +39,9 @@ fi
 
 wget -q -O $local_file $tarball_url
 tar -xf $local_file
-mv $internal_name build-tools
+rm -rf build-tools/*
+cp -r $internal_name/ build-tools/
+rm -rf $internal_name/
 git add build-tools
 echo "Updated build-tools to $tag
 


### PR DESCRIPTION
Issue: https://github.com/drud/general/issues/17 (Overall build system for drud projects)

The subtree merge technique did not work in practice. The build_update.sh script here can do an add or update and commit the results.