### PR TITLE
Change to our own container, move checks from test to build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ make VERSION=0.3.0 container
 make VERSION=0.3.0 push
 make clean
 ```
+
+## Options
+
+The compile/build targets (linux/darwin) by default run "go vet", "go fmt" and "vendorcheck". This behavior can be overridden by setting the EXTENDED_CHECKS environment variable to 'false' or by specifying it on the make command line: `make EXTENDED_CHECKS=false`.
+
+## Golang compiler component
+
+golang projects are built in a container from drud/golang-build-container (from https://github.com/drud/golang-build-container). They pick up the "latest" tag by default, so that should be updated when we choose to move to a newer golang version.

--- a/build-scripts/build_go.sh
+++ b/build-scripts/build_go.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ -z "$EXTENDED_CHECKS" ]; then EXTENDED_CHECKS=true; fi
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -40,3 +42,55 @@ go install                                                     \
     -installsuffix "static"                                        \
     -ldflags "-X ${PKG}/pkg/version.VERSION=${VERSION}"            \
     $TARGETS
+
+if [ "$EXTENDED_CHECKS" = "false" ]; then
+	echo "EXTENDED_CHECKS=false so skipping gofmt/govet/vendorcheck"
+else
+	echo "EXTENDED_CHECKS=true so doing gofmt/govet/vendorcheck"
+	echo -n "Checking gofmt: "
+	ERRS=$(find "$@" -type f -name \*.go | xargs gofmt -l 2>&1 || true)
+	if [ -n "${ERRS}" ]; then
+		echo "FAIL - the following files need to be gofmt'ed:"
+		for e in ${ERRS}; do
+			echo "    $e"
+		done
+		echo
+		exit 1
+	fi
+	echo "PASS"
+	echo
+
+	# go vet seems not to work cross-platform, so force GOOS
+	echo -n "Checking go vet ${TARGETS}: "
+	ERRS=$(GOOS=linux go vet ${TARGETS} 2>&1 || true)
+	if [ -n "${ERRS}" ]; then
+		echo "FAIL"
+		echo "${ERRS}"
+		echo
+		exit 1
+	fi
+	echo "PASS"
+	echo
+
+	echo -n "Checking vendorcheck: "
+	ERRS=$(vendorcheck -t 2>&1 || true)
+	if [ -n "${ERRS}" ]; then
+		echo "FAIL"
+		echo "${ERRS}"
+		echo
+		exit 1
+	fi
+	echo "PASS"
+	echo
+
+	echo -n "Checking vendorcheck -u for unused vendors:"
+	ERRS=$(vendorcheck -t -u  2>&1 || true)
+	if [ -n "${ERRS}" ]; then
+		echo "FAIL"
+		echo "${ERRS}"
+		echo
+		exit 1
+	fi
+	echo "PASS"
+	echo
+fi

--- a/build-scripts/build_go.sh
+++ b/build-scripts/build_go.sh
@@ -83,8 +83,8 @@ else
 	echo "PASS"
 	echo
 
-	echo -n "Checking vendorcheck -u for unused vendors:"
-	ERRS=$(vendorcheck -t -u  2>&1 || true)
+	echo -n "Checking for unused vendors:"
+	ERRS=$(govendor list +unused  2>&1 || true)
 	if [ -n "${ERRS}" ]; then
 		echo "FAIL"
 		echo "${ERRS}"

--- a/build-scripts/test_go.sh
+++ b/build-scripts/test_go.sh
@@ -33,26 +33,3 @@ go test -i -installsuffix "static" ${TARGETS}
 go test -installsuffix "static" ${TARGETS}
 echo
 
-echo -n "Checking gofmt: "
-ERRS=$(find "$@" -type f -name \*.go | xargs gofmt -l 2>&1 || true)
-if [ -n "${ERRS}" ]; then
-    echo "FAIL - the following files need to be gofmt'ed:"
-    for e in ${ERRS}; do
-        echo "    $e"
-    done
-    echo
-    exit 1
-fi
-echo "PASS"
-echo
-
-echo -n "Checking go vet ${TARGETS}: "
-ERRS=$(go vet ${TARGETS} 2>&1 || true)
-if [ -n "${ERRS}" ]; then
-    echo "FAIL"
-    echo "${ERRS}"
-    echo
-    exit 1
-fi
-echo "PASS"
-echo

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
-BUILD_IMAGE ?= golang:1.7-alpine
+BUILD_IMAGE ?= drud/golang-build-container
 
 BUILD_BASE_DIR ?= $$PWD
 
@@ -31,6 +31,7 @@ linux darwin: $(GOFILES)
 	    -v $$(pwd)/bin/$@:/go/bin/$@                      \
 	    -v $$(pwd)/.go/std/$@:/usr/local/go/pkg/$@_amd64_static  \
 	    -e GOOS=$@	\
+	    -e EXTENDED_CHECKS=$(EXTENDED_CHECKS)    \
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
 	    /bin/sh -c "                                                       \

--- a/makefile_components/base_container.mak
+++ b/makefile_components/base_container.mak
@@ -4,6 +4,7 @@
 ##### contents into ../Makefile and commenting out the include and adding a
 ##### comment about what you did and why.
 
+SANITIZED_DOCKER_REPO = $(subst /,_,$(DOCKER_REPO))
 
 DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
 
@@ -12,6 +13,7 @@ container: linux .container-$(DOTFILE_IMAGE) container-name
 .container-$(DOTFILE_IMAGE): linux Dockerfile.in
 	@sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile
 	@echo "$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
+	@echo "ADD .docker_image /$(SANITIZED_DOCKER_REPO)_VERSION_INFO.txt" >>.dockerfile
 	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) -f .dockerfile .
 	@docker images -q $(DOCKER_REPO):$(VERSION) > $@
 

--- a/makefile_components/base_container.mak
+++ b/makefile_components/base_container.mak
@@ -11,9 +11,9 @@ container: linux .container-$(DOTFILE_IMAGE) container-name
 
 .container-$(DOTFILE_IMAGE): linux Dockerfile.in
 	@sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile
+	@echo "$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
 	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) -f .dockerfile .
 	@docker images -q $(DOCKER_REPO):$(VERSION) > $@
-	@echo $(DOCKER_REPO):$(VERSION) >.docker_image
 
 container-name:
 	@echo "container: $(DOCKER_REPO):$(VERSION)"


### PR DESCRIPTION
This PR 
* switches to use our own intermediate golang container instead of using the direct golang official container.
* Adds the vendorcheck and govendor tools
* Moves gofmt/govendor tests to the build/compile phase instead of the test target
* Adds vendorcheck and govendor list +unused
* Adds repo_name_VERSION_INFO.txt into dockerfile with git commit info

The reason for moving the gofmt and related to the build target is that we sometimes test directly (rather than in the container) so those checks were being skipped when the test target was overrridden. But we always build in the container. 

The extended checks can be overridden with EXTENDED_CHECKS=true either in environment or on make invocation.

Testing suggestions:
* Install this version of build-tools into a golang project with a container
* Try building with `make darwin` - see the vendorcheck stuff now happening with compile, verify behavior.
* Try building with `make EXTENDED_CHECKS=false` darwin - extended checks should be turned off.
* Build container with `make container`
* Run the created container and look for the *_VERSION_INFO.txt in the root, view the contents.