### PR TITLE
Separate static analysis tools into new targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Using this base will allow you to build with standard targets like build, test, 
 make 
 make linux
 make darwin
+make gofmt 
+make govet
+make vendorcheck
+make golint
+make static (gofmt, govet, golint, vendorcheck)
 make test
 make container
 make push
@@ -47,10 +52,6 @@ make VERSION=0.3.0 push
 make clean
 ```
 
-## Options
-
-The compile/build targets (linux/darwin) by default run "go vet", "go fmt" and "vendorcheck". This behavior can be overridden by setting the EXTENDED_CHECKS environment variable to 'false' or by specifying it on the make command line: `make EXTENDED_CHECKS=false`.
-
 ## Golang compiler component
 
-golang projects are built in a container from drud/golang-build-container (from https://github.com/drud/golang-build-container). They pick up the "latest" tag by default, so that should be updated when we choose to move to a newer golang version.
+golang projects and static analysis functions like gofmt are built in a container from drud/golang-build-container (from https://github.com/drud/golang-build-container). They pick up the "latest" tag by default, so that should be updated when we choose to move to a newer golang version.

--- a/build-scripts/build_go.sh
+++ b/build-scripts/build_go.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -z "$EXTENDED_CHECKS" ]; then EXTENDED_CHECKS=true; fi
-
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -42,55 +40,3 @@ go install                                                     \
     -installsuffix "static"                                        \
     -ldflags "-X ${PKG}/pkg/version.VERSION=${VERSION}"            \
     $TARGETS
-
-if [ "$EXTENDED_CHECKS" = "false" ]; then
-	echo "EXTENDED_CHECKS=false so skipping gofmt/govet/vendorcheck"
-else
-	echo "EXTENDED_CHECKS=true so doing gofmt/govet/vendorcheck"
-	echo -n "Checking gofmt: "
-	ERRS=$(find "$@" -type f -name \*.go | xargs gofmt -l 2>&1 || true)
-	if [ -n "${ERRS}" ]; then
-		echo "FAIL - the following files need to be gofmt'ed:"
-		for e in ${ERRS}; do
-			echo "    $e"
-		done
-		echo
-		exit 1
-	fi
-	echo "PASS"
-	echo
-
-	# go vet seems not to work cross-platform, so force GOOS
-	echo -n "Checking go vet ${TARGETS}: "
-	ERRS=$(GOOS=linux go vet ${TARGETS} 2>&1 || true)
-	if [ -n "${ERRS}" ]; then
-		echo "FAIL"
-		echo "${ERRS}"
-		echo
-		exit 1
-	fi
-	echo "PASS"
-	echo
-
-	echo -n "Checking vendorcheck: "
-	ERRS=$(vendorcheck -t 2>&1 || true)
-	if [ -n "${ERRS}" ]; then
-		echo "FAIL"
-		echo "${ERRS}"
-		echo
-		exit 1
-	fi
-	echo "PASS"
-	echo
-
-	echo -n "Checking for unused vendors:"
-	ERRS=$(govendor list +unused  2>&1 || true)
-	if [ -n "${ERRS}" ]; then
-		echo "FAIL"
-		echo "${ERRS}"
-		echo
-		exit 1
-	fi
-	echo "PASS"
-	echo
-fi

--- a/circle.yml.example
+++ b/circle.yml.example
@@ -1,10 +1,39 @@
-machine:
-    services:
-        - docker
+version: 2
+executorType: machine
+stages:
+  build:
+    workDir: ~/bootstrap
+    environment:
+      GOPATH: /home/circleci
+      DRUD_DEBUG: "true"
+    steps:
+      - type: checkout
 
-#dependencies:
-#    pre:
+      - type: shell
+        command: sudo apt-get update && sudo apt-get install golang
+        name: Upgrade golang
 
-test:
-    override:
-        - make test
+      # Create environment which respects GOPATH
+      - type: shell
+        command: |
+          mkdir -p ~/src/github.com/drud &&
+          ln -s ~/bootstrap ~/src/github.com/drud/bootstrap &&
+          cd  ~/src/github.com/drud/bootstrap/cli &&
+          pwd
+        name: Set up directory structure
+
+      # Build drud and move it into /usr/local/bin - tests look for it in $PATH
+      - type: shell
+        command: |
+          cd  ~/src/github.com/drud/bootstrap/cli &&
+          make GOPATH=~/ linux &&
+          sudo cp bin/linux/drud /usr/local/bin/
+        name: Build the linux drud executable binary
+
+      # Run the tests
+      - type: shell
+        command: make test
+
+      # Static analysis, vendorcheck, etc.
+      - type: shell
+        command: make vendorcheck gofmt govet

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -5,7 +5,7 @@
 ##### comment about what you did and why.
 
 
-.PHONY: all build test push clean container-clean bin-clean version
+.PHONY: all build test push clean container-clean bin-clean version static vendorcheck gofmt govet golint
 
 SHELL := /bin/bash
 
@@ -14,6 +14,8 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 BUILD_IMAGE ?= drud/golang-build-container
 
 BUILD_BASE_DIR ?= $$PWD
+
+SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
 
 build: linux darwin
 
@@ -42,6 +44,57 @@ linux darwin: $(GOFILES)
 	    "
 	@touch $@
 	@echo $(VERSION) >VERSION.txt
+
+static: vendorcheck gofmt govet lint
+
+vendorcheck:
+	echo -n "Checking vendorcheck for missing dependencies and unused dependencies: "
+	@docker run                                                            \
+                 	    -t                                                                \
+                 	    -u root:root                                             \
+                 	    -v $(BUILD_BASE_DIR)/build-tools:/build-tools		\
+                 	    -v $$(pwd)/.go:/go                                                 \
+                 	    -v $$(pwd):/go/src/$(PKG)                                          \
+                 	    -w /go/src/$(PKG)                                                  \
+                 	    $(BUILD_IMAGE)                                                     \
+                 	    bash -c 'OUT=$$(vendorcheck ./... && govendor list +unused); if [ -n "$$OUT" ]; then echo "$$OUT"; exit 1; fi'
+
+gofmt:
+	echo -n "Checking gofmt: "
+	@docker run                                                            \
+                 	    -t                                                                \
+                 	    -u root:root                                             \
+                 	    -v $(BUILD_BASE_DIR)/build-tools:/build-tools		\
+                 	    -v $$(pwd)/.go:/go                                                 \
+                 	    -v $$(pwd):/go/src/$(PKG)                                          \
+                 	    -w /go/src/$(PKG)                                                  \
+                 	    $(BUILD_IMAGE)                                                     \
+                 	    bash -c 'gofmt -l $(SRC_DIRS)'
+
+govet:
+	echo -n "Checking go vet: "
+	docker run                                                            \
+                 	    -t                                                                \
+                 	    -u root:root                                             \
+                 	    -v $(BUILD_BASE_DIR)/build-tools:/build-tools		\
+                 	    -v $$(pwd)/.go:/go                                                 \
+                 	    -v $$(pwd):/go/src/$(PKG)                                          \
+                 	    -w /go/src/$(PKG)                                                  \
+                 	    $(BUILD_IMAGE)                                                     \
+                 	    bash -c 'go vet $(SRC_AND_UNDER)'
+
+golint:
+	echo -n "Checking golint: "
+	docker run                                                            \
+                 	    -t                                                                \
+                 	    -u root:root                                             \
+                 	    -v $(BUILD_BASE_DIR)/build-tools:/build-tools		\
+                 	    -v $$(pwd)/.go:/go                                                 \
+                 	    -v $$(pwd):/go/src/$(PKG)                                          \
+                 	    -w /go/src/$(PKG)                                                  \
+                 	    $(BUILD_IMAGE)                                                     \
+                 	    bash -c 'golint $(SRC_AND_UNDER)'
+
 
 version:
 	@echo VERSION:$(VERSION)

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -33,7 +33,6 @@ linux darwin: $(GOFILES)
 	    -v $$(pwd)/bin/$@:/go/bin/$@                      \
 	    -v $$(pwd)/.go/std/$@:/usr/local/go/pkg/$@_amd64_static  \
 	    -e GOOS=$@	\
-	    -e EXTENDED_CHECKS=$(EXTENDED_CHECKS)    \
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
 	    /bin/sh -c "                                                       \


### PR DESCRIPTION
This moves the static analysis tools into separate targets, no variable now needed. The check can be included in circle.yml, but need not slow down ordinary compiles.
```
make gofmt
make golint
make vendorcheck
make govet
make static (all 4)
make gofmt vendorcheck govet (standard check)
```