### PR TITLE
Fix broken linking behavior introduced with VERSION_LDFLAGS changes

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -43,3 +43,7 @@ include build-tools/makefile_components/base_container.mak
 include build-tools/makefile_components/base_push.mak
 include build-tools/makefile_components/base_test_go.mak
 #include build-tools/makefile_components/base_test_python.mak
+
+
+# Additional targets can be added here
+# Also, existing targets can be overridden by copying and customizing them.

--- a/Makefile.example
+++ b/Makefile.example
@@ -18,6 +18,10 @@ SRC_DIRS := files drudapi secrets utils
 # These are replaced in the $(PKG).version package.
 # VERSION_VARIABLES = ThisCmdVersion ThatContainerVersion
 
+# These variables will be used as the defaults unless overridden by the make command line
+#ThisCmdVersion ?= $(VERSION)
+#ThatContainerVersion ?= drud/nginx-php-fpm7-local
+
 # Optional to docker build
 # DOCKER_ARGS =
 

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -18,9 +18,12 @@ BUILD_BASE_DIR ?= $$PWD
 # Expands SRC_DIRS into the common golang ./dir/... format for "all below"
 SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
 
+
 VERSION_VARIABLES += VERSION
 
-VERSION_LDFLAGS := -ldflags "$(foreach v,$(VERSION_VARIABLES),-X $(PKG)/pkg/version.$(v)=$($(v)))"
+VERSION_LDFLAGS := $(foreach v,$(VERSION_VARIABLES),-X $(PKG)/pkg/version.$(v)=$($(v)))
+
+LDFLAGS := -extldflags -static $(VERSION_LDFLAGS)
 
 build: linux darwin
 
@@ -36,13 +39,12 @@ linux darwin: $(GOFILES)
 	    -v $$(pwd)/bin/$@:/go/bin                                     \
 	    -v $$(pwd)/bin/$@:/go/bin/$@                      \
 	    -v $$(pwd)/.go/std/$@:/usr/local/go/pkg/$@_amd64_static  \
+	    -e CGO_ENABLED=0                  \
 	    -w /go/src/$(PKG)                 \
 	    $(BUILD_IMAGE)                    \
 	    /bin/sh -c '                      \
 	        GOOS=$@                       \
-	        go install -installsuffix 'static'   \
-                $(VERSION_LDFLAGS) \
-                $(SRC_AND_UNDER)  \
+	        go install -installsuffix 'static' -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)  \
 	    '
 	@touch $@
 	@echo $(VERSION) >VERSION.txt

--- a/makefile_components/base_test_go.mak
+++ b/makefile_components/base_test_go.mak
@@ -9,16 +9,17 @@ TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 test: build
 	@mkdir -p bin/linux
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
-	docker run                                                            \
+	@docker run                                                            \
 	    -t                                                                \
 	    -u $(shell id -u):$(shell id -g)                                             \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/linux:/go/bin                                     \
 	    -v $$(pwd)/.go/std/linux:/usr/local/go/pkg/linux_amd64_static  \
+	    -e CGO_ENABLED=0	\
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
 	    /bin/bash -c '                                                    \
 	        GOOS=`uname -s |  tr '[:upper:]' '[:lower:]'`  &&		\
-	        go test -v -installsuffix "static" $(VERSION_LDFLAGS) $(SRC_AND_UNDER)   \
+	        go test -v -installsuffix "static" -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)   \
 	    '

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -52,7 +52,7 @@ include ../makefile_components/base_push.mak
 test: build
 	@mkdir -p bin/linux
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
-	go test -v -installsuffix "static" $(VERSION_LDFLAGS) $(SRC_AND_UNDER)
+	go test -v -installsuffix "static" -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)
 
 # Simple way to execute a random command in the container for tests - used only for testing
 # Example: make COMMAND="govendor fetch golang.org/x/net/context"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,8 +17,12 @@ export WORKING_DIR = $(shell pwd)
 SRC_DIRS := cmd pkg
 
 # Version variables to replace in build, The variable VERSION is automatically pulled from git committish so it doesn't have to be added
-# These are replaced in the $(PKG).version package.
-VERSION_VARIABLES = VERSION
+# These are replaced in the $(PKG).version package DBImg DBTag RouterImage RouterTag
+#VERSION_VARIABLES = DdevVersion WebImg
+
+# These variables will be used as the default unless overridden by the make command line
+#DdevVersion ?= $(VERSION)
+#WebImg ?= drud/nginx-php-fpm7-local
 
 # Optional to docker build
 # DOCKER_ARGS =


### PR DESCRIPTION
I introduced basic build and testing problems in https://github.com/drud/build-tools/pull/5 - this fixes them.

* Separates ldflags from the VERSION_LDFLAGS
* Adds ldflags to test as well as compile
* Makes the darwin build work again

Testing: This is introduced into ddev in https://github.com/drud/ddev/pull/25 - So that's a practical example. I will also begin adding basic test capabilities in a separate PR.

Automated testing requires:
- [ ] Check darwin binary for correct type (use file command - maybe there's another technique?)
- [ ] Check linux binary for correct type

I'm not sure there would be a way to generate and detect a bad version, but the test should be written to do that. 