### PR TITLE
adds release target to be used w/ rlsr

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -12,7 +12,10 @@ PKG := github.com/drud/repo_name
 # UPSTREAM_REPO ?= full/upstream-docker-repo
 
 # Top-level directories to build
-SRC_DIRS := files drudapi secrets utils
+SRC_DIRS := cmd pkg
+
+# Golang binary name
+BIN_NAME := $$PWD
 
 # Version variables to replace in build, The variable VERSION is automatically pulled from git committish so it doesn't have to be added
 # These are replaced in the $(PKG).version package.

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -5,7 +5,7 @@
 ##### comment about what you did and why.
 
 
-.PHONY: all build test push clean container-clean bin-clean version static vendorcheck gofmt govet golint
+.PHONY: all build test push clean container-clean bin-clean version static vendorcheck gofmt govet golint release
 
 SHELL := /bin/bash
 
@@ -93,6 +93,11 @@ golint:
                  	    $(BUILD_IMAGE)                                                     \
                  	    bash -c 'golint $(SRC_AND_UNDER)'
 
+release: build
+	@mkdir -p $(BUILD_BASE_DIR)/.artifacts
+	@tar -czf $(BUILD_BASE_DIR)/.artifacts/$(BIN_NAME)-macOS.tar.gz -C $(BUILD_BASE_DIR)/bin/darwin/darwin_amd64/ $(BIN_NAME)
+	@tar -czf $(BUILD_BASE_DIR)/.artifacts/$(BIN_NAME)-linux.tar.gz -C $(BUILD_BASE_DIR)/bin/linux/ $(BIN_NAME)
+
 
 version:
 	@echo VERSION:$(VERSION)
@@ -103,7 +108,7 @@ container-clean:
 	rm -rf .container-* .dockerfile* .push-* linux darwin container VERSION.txt .docker_image
 
 bin-clean:
-	rm -rf .go bin .tmp
+	rm -rf .go bin .tmp .artifacts
 
 # print-ANYVAR prints the expanded variable
 print-%: ; @echo $* = $($*)


### PR DESCRIPTION
This adds a new target to be leveraged by [rlsr](https://github.com/drud/rlsr) for golang projects. It will run a build and archive the resulting binaries in the `.artifacts` folder. This allows you to then run `rlsr` with a valid `releases.yaml` against the project.