### PR TITLE
Remove build-tools circle.yml when updating, as it isn't relevant

### DIFF
--- a/build_update.sh
+++ b/build_update.sh
@@ -40,7 +40,7 @@ tar -xf $local_file
 rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
-rm -rf build-tools/tests/
+rm -rf build-tools/tests/ build-tools/circle.yml
 git add build-tools
 echo "Updated build-tools to $tag
 


### PR DESCRIPTION
I noticed when updating ddev that the build-tools circle.yml (which as always is in top level) was left in there, which could confuse somebody in the future. This removes it during the installation with the script.