### PR TITLE
Remove failed newlines from .docker_image

### DIFF
--- a/makefile_components/base_container.mak
+++ b/makefile_components/base_container.mak
@@ -12,7 +12,7 @@ container: linux .container-$(DOTFILE_IMAGE) container-name
 
 .container-$(DOTFILE_IMAGE): linux Dockerfile.in
 	@sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile
-	@echo "\n\n$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
+	@echo "$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
 	@echo "ADD .docker_image /$(SANITIZED_DOCKER_REPO)_VERSION_INFO.txt" >>.dockerfile
 	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) -f .dockerfile .
 	@docker images -q $(DOCKER_REPO):$(VERSION) > $@


### PR DESCRIPTION
The failed write of "\n\n" in .docker-image resulted in a circle.yml usage failure elsewhere. This is a fairly trivial problem and can be solved elsewhere, but that "\n\n" shouldn't be in .docker-image anyway.