### PR TITLE
Remove spurious single-quotes in golang build statement

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -44,7 +44,7 @@ linux darwin: $(GOFILES)
 	    $(BUILD_IMAGE)                    \
 	    /bin/sh -c '                      \
 	        GOOS=$@                       \
-	        go install -installsuffix 'static' -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)  \
+	        go install -installsuffix static -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)  \
 	    '
 	@touch $@
 	@echo $(VERSION) >VERSION.txt


### PR DESCRIPTION
Researching @beeradb 's problems in build I noted that there are nested single quotes in the build statement - I am not sure how it could work with those in there. I don't think this is related to his occasional build oddities, but it needs to be fixed.