### PR TITLE
Use --rm on docker commands

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -31,9 +31,7 @@ linux darwin: $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)"
 	@rm -f VERSION.txt
 	@mkdir -p bin/$@ .go/std/$@ .go/bin .go/src/$(PKG)
-	docker run                                                            \
-	    -t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/$@:/go/bin                                     \
@@ -53,9 +51,7 @@ static: govendor gofmt govet lint
 
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "
-	docker run                                                            \
-		-t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -64,9 +60,7 @@ govendor:
 
 gofmt:
 	@echo "Checking gofmt: "
-	docker run                                                            \
-		-t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -75,9 +69,7 @@ gofmt:
 
 govet:
 	@echo -n "Checking go vet: "
-	docker run                                                            \
-		-t                                                                \
-		-u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -86,9 +78,7 @@ govet:
 
 golint:
 	@echo -n "Checking golint: "
-	docker run                                                            \
-		-t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \

--- a/makefile_components/base_test_go.mak
+++ b/makefile_components/base_test_go.mak
@@ -9,9 +9,7 @@ TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 test: build
 	@mkdir -p bin/linux
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
-	@docker run                                                            \
-	    -t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	@docker run -t --rm  -u $(shell id -u):$(shell id -g)                 \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/linux:/go/bin                                     \
@@ -20,6 +18,6 @@ test: build
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
 	    /bin/bash -c '                                                    \
-	        GOOS=`uname -s |  tr '[:upper:]' '[:lower:]'`  &&		\
-	        go test -v -installsuffix "static" -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)   \
+	        GOOS=`uname -s |  tr "[:upper:]" "[:lower:]"`  &&		\
+	        go test -v -installsuffix static -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)   \
 	    '


### PR DESCRIPTION
We are leaving lots of golang-build-container 's around, and it makes no sense to do that. Instead we should use the --rm flag on our docker invocations. Thanks @beeradb 