### PR TITLE
Add github issue status to build-tools

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What happened (or feature request):
+
+
+## What you expected to happen:
+
+
+## How to reproduce it (as minimally and precisely as possible):
+
+
+## Anything else do we need to know:
+
+## Related source links or issues (like source JIRA issue):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## The Problem:
+
+## The Fix:
+
+## The Test:
+
+## Automation Overview:
+<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
+
+## Related Issue Link(s):
+
+## Release/Deployment notes:
+Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?
+

--- a/build_update.sh
+++ b/build_update.sh
@@ -40,7 +40,7 @@ tar -xf $local_file
 rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
-rm -rf build-tools/tests/ build-tools/circle.yml
+rm -rf build-tools/tests/ build-tools/circle.yml build-tools/.github
 git add build-tools
 echo "Updated build-tools to $tag
 


### PR DESCRIPTION
This just adds .github from ddev (and rm's it on deployment)