### PR TITLE
Fixes #13 by adding a version file on update

### DIFF
--- a/build_update.sh
+++ b/build_update.sh
@@ -41,6 +41,7 @@ rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
 rm -rf build-tools/tests/ build-tools/circle.yml build-tools/.github
+touch build-tools/build-tools-VERSION-$tag.txt
 git add build-tools
 echo "Updated build-tools to $tag
 


### PR DESCRIPTION
## The Problem:

It's useful to know what version of build-tools a project currently has installed, and it's not easy to know it right now.

## The Fix:

Add a version file.


## Related Issue Link(s):

#13 requested this feature.

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

