### PR TITLE
Bump golang-build-container to v0.2.0, add static analysis targets

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
-BUILD_IMAGE ?= drud/golang-build-container:0.1.0
+BUILD_IMAGE ?= drud/golang-build-container:v0.2.0
 
 BUILD_BASE_DIR ?= $$PWD
 

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -85,6 +85,33 @@ golint:
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'export OUT=$$(golint $(SRC_AND_UNDER)) && if [ -n "$$OUT" ]; then echo "Golint problems discovered: $$OUT"; exit 1; fi'
 
+errcheck:
+	@echo -n "Checking errcheck: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		errcheck $(SRC_AND_UNDER)
+
+staticcheck:
+	@echo -n "Checking staticcheck: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		staticcheck $(SRC_AND_UNDER)
+
+unused:
+	@echo -n "Checking unused variables and functions: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		unused $(SRC_AND_UNDER)
+
 
 version:
 	@echo VERSION:$(VERSION)

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -112,6 +112,15 @@ unused:
 		$(BUILD_IMAGE)                                                     \
 		unused $(SRC_AND_UNDER)
 
+varcheck:
+	@echo -n "Checking unused globals and struct members: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		varcheck $(SRC_AND_UNDER) && structcheck $(SRC_AND_UNDER)
+
 
 version:
 	@echo VERSION:$(VERSION)

--- a/makefile_components/base_build_python-docker.mak
+++ b/makefile_components/base_build_python-docker.mak
@@ -9,7 +9,7 @@
 
 SHELL := /bin/bash
 
-BUILD_IMAGE ?= golang:1.7-alpine
+BUILD_IMAGE ?= drud/golang-build-container:v0.2.0
 
 all: VERSION.txt build
 

--- a/tests/pkg/dirtyComplex/bad_errcheck_code.go
+++ b/tests/pkg/dirtyComplex/bad_errcheck_code.go
@@ -1,0 +1,8 @@
+package dirtyComplex
+
+import "os"
+
+// AFuncWithMissingErrCheck doesn't do anything useful - it just fails, and the err is lost
+func AFuncWithMissingErrCheck(s string) {
+	os.Chown("/never/will/this/file/exist", 99999, 99999)
+}

--- a/tests/pkg/dirtyComplex/bad_staticcheck_code.go
+++ b/tests/pkg/dirtyComplex/bad_staticcheck_code.go
@@ -1,0 +1,10 @@
+package dirtyComplex
+
+import "fmt"
+
+// AnotherExportedFunction doesn't do anything but introduce an unused return for staticcheck
+func AnotherExportedFunction(s string) {
+	num, err := fmt.Println(s)
+	num, err = fmt.Println(s)
+	fmt.Println(num, err)
+}

--- a/tests/pkg/dirtyComplex/bad_unused_code.go
+++ b/tests/pkg/dirtyComplex/bad_unused_code.go
@@ -1,0 +1,7 @@
+package dirtyComplex
+
+// SomeExportedFunction doesn't do anything but introduce an unused return for staticcheck
+func yetAnotherExportedFunction() int {
+	x := 1
+	return x
+}


### PR DESCRIPTION
## The Problem:

Build container has been updated to v0.2.0 for golang 1.8.1, see https://github.com/drud/golang-build-container/pull/1

## The Fix:

* Change the tag we use. 
* Add more static analysis targets, especially errcheck

A provisional v0.2.0 has been pushed to drud/golang-build-container

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

https://github.com/drud/golang-build-container/pull/1

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

