### PR TITLE
Add codecoroner build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ cd build-tools
 Using this base will allow you to build with standard targets like build, test, container, push, clean:
 
 ```
-make 
+make
 make linux
 make darwin
-make gofmt 
+make gofmt
 make govet
 make govendor
 make golint
+make codecoroner
 make static (gofmt, govet, golint, govendor)
 make test
 make container

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.2.0
+BUILD_IMAGE ?= drud/golang-build-container:codecoroner
 
 BUILD_BASE_DIR ?= $$PWD
 
@@ -111,6 +111,16 @@ unused:
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		unused $(SRC_AND_UNDER)
+
+codecoroner:
+	@echo -n "Checking codecoroner for unused functions: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE) \
+		bash -c 'OUT=$$(codecoroner -tests -ignore vendor funcs $(SRC_AND_UNDER)); if [ -n "$$OUT" ]; then echo "$$OUT"; exit 1; fi'                                             \
+
 
 varcheck:
 	@echo -n "Checking unused globals and struct members: "

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
-BUILD_IMAGE ?= drud/golang-build-container:codecoroner
+BUILD_IMAGE ?= drud/golang-build-container:v0.3.0
 
 BUILD_BASE_DIR ?= $$PWD
 

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"fmt"
-	"github.com/drud/build-tools/tests/pkg/version"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/drud/build-tools/tests/pkg/version"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -204,6 +205,20 @@ func TestUnused(t *testing.T) {
 
 	// Test "make unused"
 	v, err := exec.Command("make", "unused").Output()
+	assert.Error(err) // Should have one complaint about bad_unused_code.go
+	assert.Contains(string(v), "pkg/dirtyComplex/bad_unused_code.go")
+
+	// Test "make SRC_DIRS=pkg/clean unused" to limit to just clean directories
+	_, err = exec.Command("make", "SRC_DIRS=pkg/clean", "unused").Output()
+	assert.NoError(err) // Should have no complaints in clean package
+}
+
+// Test codecoroner.
+func TestCodeCoroner(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test "make unused"
+	v, err := exec.Command("make", "codecoroner").Output()
 	assert.Error(err) // Should have one complaint about bad_unused_code.go
 	assert.Contains(string(v), "pkg/dirtyComplex/bad_unused_code.go")
 

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -219,8 +219,9 @@ func TestCodeCoroner(t *testing.T) {
 
 	// Test "make unused"
 	v, err := exec.Command("make", "codecoroner").Output()
-	assert.Error(err) // Should have one complaint about bad_unused_code.go
-	assert.Contains(string(v), "pkg/dirtyComplex/bad_unused_code.go")
+	assert.Error(err)                                        // Should complain about pretty much everything in the dirtyComplex package.
+	assert.Contains(string(v), "AnotherExportedFunction")    // Check an exported function
+	assert.Contains(string(v), "yetAnotherExportedFunction") // Check an unexported function.
 
 	// Test "make SRC_DIRS=pkg/clean unused" to limit to just clean directories
 	_, err = exec.Command("make", "SRC_DIRS=pkg/clean", "unused").Output()

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -217,13 +217,13 @@ func TestUnused(t *testing.T) {
 func TestCodeCoroner(t *testing.T) {
 	assert := assert.New(t)
 
-	// Test "make unused"
+	// Test "make codecoroner"
 	v, err := exec.Command("make", "codecoroner").Output()
 	assert.Error(err)                                        // Should complain about pretty much everything in the dirtyComplex package.
 	assert.Contains(string(v), "AnotherExportedFunction")    // Check an exported function
 	assert.Contains(string(v), "yetAnotherExportedFunction") // Check an unexported function.
 
-	// Test "make SRC_DIRS=pkg/clean unused" to limit to just clean directories
+	// Test "make SRC_DIRS=pkg/clean codecoroner" to limit to just clean directories
 	_, err = exec.Command("make", "SRC_DIRS=pkg/clean", "unused").Output()
 	assert.NoError(err) // Should have no complaints in clean package
 }


### PR DESCRIPTION
## The Problem:
It's nice to detect unused code. Currently we have a `make unused` target, but that doesn't appear to get exported functions. Code coroner (https://github.com/3rf/codecoroner) does, and from my tests against ddev appears to work fairly well.

## The Fix:
Add a `codecoroner` build target, as well as tests to support them

## The Test:
Simply run `make codecoroner` against the tests in this repo, and you'll see it rightfully complain that much of the code is not used.

## Automation Overview:
There are automated tests for this in the `TestCodeCoroner` function which were derived from the existing tests for the `unused` target.

## Deployment steps
I've pushed a provisional `codecoroner` tag for the build container to docker hub. If the code here looks good, we need to:

- [x] Approve the PR at https://github.com/drud/golang-build-container/pull/2
- [x] Roll a new build container tag
- [x] Update this PR to use that new build container tag
- [ ] Merge this PR
- [ ] Create a new release of build-tools