### PR TITLE
Add buildinfo date/context to standard build

### DIFF
--- a/makefile_components/base_test_go.mak
+++ b/makefile_components/base_test_go.mak
@@ -15,9 +15,7 @@ test: build
 	    -v $$(pwd)/bin/linux:/go/bin                                     \
 	    -v $$(pwd)/.go/std/linux:/usr/local/go/pkg/linux_amd64_static  \
 	    -e CGO_ENABLED=0	\
+	    -e GOOS=$$(uname -s |  tr "[:upper:]" "[:lower:]")
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
-	    /bin/bash -c '                                                    \
-	        GOOS=`uname -s |  tr "[:upper:]" "[:lower:]"`  &&		\
-	        go test -v -installsuffix static -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)   \
-	    '
+        go test -v -installsuffix static -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -56,7 +56,7 @@ include ../makefile_components/base_push.mak
 test: build
 	@mkdir -p bin/linux
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
-	go test -v -installsuffix "static" -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)
+	go test -v -installsuffix "static" -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER) $(TESTARGS)
 
 # Simple way to execute a random command in the container for tests - used only for testing
 # Example: make COMMAND="govendor fetch golang.org/x/net/context"

--- a/tests/cmd/build_tools_dummy/build_tools_dummy.go
+++ b/tests/cmd/build_tools_dummy/build_tools_dummy.go
@@ -6,5 +6,8 @@ import (
 )
 
 func main() {
-	fmt.Println("This is build_tools_dummy.go version=" + version.VERSION)
+	fmt.Println("This is build_tools_dummy.go version=")
+	fmt.Println("Version:", version.VERSION)
+	fmt.Println("Commit:", version.COMMIT)
+	fmt.Println("Buildinfo:", version.BUILDINFO)
 }

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -75,6 +75,10 @@ func TestBuild(t *testing.T) {
 	a.NoError(err)
 	a.Contains(string(v), "This is build_tools_dummy.go")
 	a.Contains(string(v), version.VERSION)
+	a.Contains(string(v), version.COMMIT)
+	a.Contains(string(v), "Built ")
+	a.NotContains(string(v), "COMMIT should be overridden")
+	a.NotContains(string(v), "BUILDINFO should have new info")
 
 	// Make container
 	v, err = exec.Command("make", "container").Output()

--- a/tests/pkg/version/version.go
+++ b/tests/pkg/version/version.go
@@ -1,4 +1,7 @@
 package version
 
-// VERSION is supplied with the git committish this is built from
+// VERSION is supplied with the git committish (or overridden $VERSION) this is built from
 var VERSION = ""
+
+var COMMIT = "COMMIT should be overridden"
+var BUILDINFO = "BUILDINFO should have new info"


### PR DESCRIPTION
## The Problem:

It would be nice to know explicit information about *commit* and *build date/time/context* from an actual executable.  

Note that currently version.VERSION *can* be the commit, but it's overridden by $(VERSION), which makes things a bit untraceable when you use `make VERSION=something`, so this makes the commit explicit.

## The Fix:

Add these items to build-tools.

## The Test:

Testing is added to TestBuild for these

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

* If the `make test` target is overridden in build-tools, it may need to have double-quotes changed to single-quotes around the LDFLAGS, as in the Makefile in tests here. For example:  `go test -v -installsuffix "static" -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER) $(TESTARGS)`
* To make use of version.BUILDINFO and version.COMMIT, those variables must be added to the pkg/version/version.go in the target executable.
