### PR TITLE
Make gitignore.example more explicit - fixes #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd build-tools
 
 ## Additional chores when installing:
 
-* Add the items from gitignore_example to your .gitignore
+* Add the items from gitignore_example to the .gitignore in each directory that has a Makefile
 * Update the project README.md to explain how to build - the target reminders in the paragraph below may be helpful.
 
 ## Basic targets and capabilities

--- a/gitignore.example
+++ b/gitignore.example
@@ -1,12 +1,12 @@
-# Add these lines to project .gitignore
+# Add these lines to the .gitignore in each directory with a Makefile
 
 # Temporary build-tools artifacts to be ignored
-.go/
-bin/
-.container*
-.push*
-linux
-darwin
-.dockerfile
-VERSION.txt
-.docker_image
+/.go/
+/bin/
+/.container*
+/.push*
+/linux
+/darwin
+/.dockerfile
+/VERSION.txt
+/.docker_image

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,10 +1,10 @@
 # Temporary build-tools artifacts to be ignored
-.go/
-bin/
-.container*
-.push*
-linux
-darwin
-.dockerfile
-VERSION.txt
-.docker_image
+/.go/
+/bin/
+/.container*
+/.push*
+/linux
+/darwin
+/.dockerfile
+/VERSION.txt
+/.docker_image


### PR DESCRIPTION
## The Problem:

The default gitignore was ignoring files it shouldn't, especially in some container repos (See #18)

## The Fix:

* Prefix paths with /
* Add comment to say that the gitignore goes with the Makefile

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

