### PR TITLE
Add gometalinter into build tools

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -11,12 +11,14 @@ SHELL := /bin/bash
 
 GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.3.0
+BUILD_IMAGE ?= drud/golang-build-container:v0.4.1
 
 BUILD_BASE_DIR ?= $$PWD
 
 # Expands SRC_DIRS into the common golang ./dir/... format for "all below"
 SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
+
+GOMETALINTER_ARGS ?= --vendored-linters --disable=gocyclo --disable=gotype --disable=goconst --disable=gas --deadline=2m
 
 
 COMMIT := $(shell git describe --tags --always --dirty)
@@ -52,7 +54,7 @@ static: govendor gofmt govet lint
 
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -61,7 +63,7 @@ govendor:
 
 gofmt:
 	@echo "Checking gofmt: "
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -69,8 +71,8 @@ gofmt:
 		bash -c 'export OUT=$$(gofmt -l $(SRC_DIRS))  && if [ -n "$$OUT" ]; then echo "These files need gofmt -w: $$OUT"; exit 1; fi'
 
 govet:
-	@echo -n "Checking go vet: "
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+	@echo "Checking go vet: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -78,8 +80,8 @@ govet:
 		bash -c 'go vet $(SRC_AND_UNDER)'
 
 golint:
-	@echo -n "Checking golint: "
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
+	@echo "Checking golint: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -87,8 +89,8 @@ golint:
 		bash -c 'export OUT=$$(golint $(SRC_AND_UNDER)) && if [ -n "$$OUT" ]; then echo "Golint problems discovered: $$OUT"; exit 1; fi'
 
 errcheck:
-	@echo -n "Checking errcheck: "
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
+	@echo "Checking errcheck: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -96,8 +98,8 @@ errcheck:
 		errcheck $(SRC_AND_UNDER)
 
 staticcheck:
-	@echo -n "Checking staticcheck: "
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+	@echo "Checking staticcheck: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -105,8 +107,8 @@ staticcheck:
 		staticcheck $(SRC_AND_UNDER)
 
 unused:
-	@echo -n "Checking unused variables and functions: "
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+	@echo "Checking unused variables and functions: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -114,8 +116,8 @@ unused:
 		unused $(SRC_AND_UNDER)
 
 codecoroner:
-	@echo -n "Checking codecoroner for unused functions: "
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+	@echo "Checking codecoroner for unused functions: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -124,14 +126,22 @@ codecoroner:
 
 
 varcheck:
-	@echo -n "Checking unused globals and struct members: "
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+	@echo "Checking unused globals and struct members: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		varcheck $(SRC_AND_UNDER) && structcheck $(SRC_AND_UNDER)
 
+gometalinter:
+	@echo "gometalinter: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		gometalinter $(GOMETALINTER_ARGS) $(SRC_AND_UNDER)
 
 version:
 	@echo VERSION:$(VERSION)

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -134,6 +134,15 @@ varcheck:
 		$(BUILD_IMAGE)                                                     \
 		varcheck $(SRC_AND_UNDER) && structcheck $(SRC_AND_UNDER)
 
+misspell:
+	@echo "Checking for misspellings: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		misspell $(SRC_DIRS)
+
 gometalinter:
 	@echo "gometalinter: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -232,6 +232,20 @@ func TestCodeCoroner(t *testing.T) {
 	assert.NoError(err) // Should have no complaints in clean package
 }
 
+// Test misspell.
+func TestMisspell(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test "make codecoroner"
+	v, err := exec.Command("make", "misspell").Output()
+	assert.Error(err)                                        // Should complain about pretty much everything in the dirtyComplex package.
+	assert.Contains(string(v), "\"mispelled\" is a misspelling of \"misspelled\"")    // Check an exported function
+
+	// Test "make SRC_DIRS=pkg/clean codecoroner" to limit to just clean directories
+	_, err = exec.Command("make", "misspell", "SRC_DIRS=pkg/clean").Output()
+	assert.NoError(err) // Should have no complaints in clean package
+}
+
 // Test gometalinter.
 func TestGoMetalinter(t *testing.T) {
 	assert := assert.New(t)

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -237,13 +237,14 @@ func TestMisspell(t *testing.T) {
 	assert := assert.New(t)
 
 	// Test "make codecoroner"
-	v, err := exec.Command("make", "misspell").Output()
-	assert.Error(err)                                        // Should complain about pretty much everything in the dirtyComplex package.
-	assert.Contains(string(v), "\"mispelled\" is a misspelling of \"misspelled\"")    // Check an exported function
+	v, err := exec.Command("make", "--no-print-directory", "misspell").Output()
+	assert.NoError(err)                                               // This one doesn't make an error return
+	assert.Contains(string(v), " is a misspelling of \"misspelled\"") // Check an exported function
 
 	// Test "make SRC_DIRS=pkg/clean codecoroner" to limit to just clean directories
-	_, err = exec.Command("make", "misspell", "SRC_DIRS=pkg/clean").Output()
+	v, err = exec.Command("make", "--no-print-directory", "misspell", "SRC_DIRS=pkg/clean").Output()
 	assert.NoError(err) // Should have no complaints in clean package
+	assert.Equal(string(v), "Checking for misspellings: \n")
 }
 
 // Test gometalinter.

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -155,7 +155,7 @@ func TestGoLint(t *testing.T) {
 	assert.Contains(string(v), "exported function DummyExported_function should have comment")
 
 	// Test "make SRC_DIRS=pkg golint" to limit to just clean directories
-	_, err = exec.Command("make", "SRC_DIRS=pkg/clean", "golint").Output()
+	_, err = exec.Command("make", "golint", "SRC_DIRS=pkg/clean").Output()
 	assert.NoError(err) // Should have one complaint about gofmtproblem.go
 }
 
@@ -170,7 +170,7 @@ func TestGoVet(t *testing.T) {
 	assert.Contains(string(v), "pkg/dirtyComplex/bad_govet_code.go")
 
 	// Test "make SRC_DIRS=pkg govet" to limit to just clean directories
-	_, err = exec.Command("make", "SRC_DIRS=pkg/clean", "govet").Output()
+	_, err = exec.Command("make", "govet", "SRC_DIRS=pkg/clean").Output()
 	assert.NoError(err) // Should have no complaints in clean package
 }
 
@@ -185,7 +185,7 @@ func TestErrCheck(t *testing.T) {
 	assert.Contains(string(v), "pkg/dirtyComplex/bad_errcheck_code.go")
 
 	// Test "make SRC_DIRS=pkg errcheck" to limit to just clean directories
-	_, err = exec.Command("make", "SRC_DIRS=pkg/clean", "errcheck").Output()
+	_, err = exec.Command("make", "errcheck", "SRC_DIRS=pkg/clean").Output()
 	assert.NoError(err) // Should have no complaints in clean package
 }
 
@@ -199,7 +199,7 @@ func TestStaticcheck(t *testing.T) {
 	assert.Contains(string(v), "pkg/dirtyComplex/bad_staticcheck_code.go")
 
 	// Test "make SRC_DIRS=pkg/clean staticcheck" to limit to just clean directories
-	_, err = exec.Command("make", "SRC_DIRS=pkg/clean", "staticcheck").Output()
+	_, err = exec.Command("make", "staticcheck", "SRC_DIRS=pkg/clean").Output()
 	assert.NoError(err) // Should have no complaints in clean package
 }
 
@@ -213,7 +213,7 @@ func TestUnused(t *testing.T) {
 	assert.Contains(string(v), "pkg/dirtyComplex/bad_unused_code.go")
 
 	// Test "make SRC_DIRS=pkg/clean unused" to limit to just clean directories
-	_, err = exec.Command("make", "SRC_DIRS=pkg/clean", "unused").Output()
+	_, err = exec.Command("make", "unused", "SRC_DIRS=pkg/clean").Output()
 	assert.NoError(err) // Should have no complaints in clean package
 }
 
@@ -228,6 +228,20 @@ func TestCodeCoroner(t *testing.T) {
 	assert.Contains(string(v), "yetAnotherExportedFunction") // Check an unexported function.
 
 	// Test "make SRC_DIRS=pkg/clean codecoroner" to limit to just clean directories
-	_, err = exec.Command("make", "SRC_DIRS=pkg/clean", "unused").Output()
+	_, err = exec.Command("make", "codecoroner", "SRC_DIRS=pkg/clean").Output()
+	assert.NoError(err) // Should have no complaints in clean package
+}
+
+// Test gometalinter.
+func TestGoMetalinter(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test "make gometalinter"
+	v, err := exec.Command("make", "gometalinter").Output()
+	assert.Error(err)                                                  // Should complain about pretty much everything in the dirtyComplex package.
+	assert.Contains(string(v), "yetAnotherExportedFunction is unused") // Check an unexported function.
+
+	// Test "make SRC_DIRS=pkg/clean codecoroner" to limit to just clean directories
+	_, err = exec.Command("make", "gometalinter", "SRC_DIRS=pkg/clean").Output()
 	assert.NoError(err) // Should have no complaints in clean package
 }

--- a/tests/pkg/dirtyComplex/bad_misspell_code.go
+++ b/tests/pkg/dirtyComplex/bad_misspell_code.go
@@ -1,0 +1,9 @@
+package dirtyComplex
+
+import "fmt"
+
+// MispeledFunction is intentionally mispelled
+// I will be dissapoint if it doesn't catch some things. Doesn't seem to catch a lot.
+func MispeledFunction(s string) {
+	fmt.Println(s)
+}


### PR DESCRIPTION
## The Problem:

gometalinter is now included in the golang_build_container, we'd like to have it easily available.

## The Fix:

* Bump default version of drud/golang_build_container
* Add gometalinter target
* Provide $(GOMETALINTER_ARGS) which can be overridden in any Makefile or on command line. (but defaults to fairly sane set)
* Quiet the linters down a bit (we don't need to see their docker commands) and make them output a newline after each one.
* Add a trivial test for `make gometalinter`
* Clean up some errors discovered in tests (many were testing unused when they weren't supposed to. Copy/paste error.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

This just adds a trivial test for the gometalinter target.

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

