### PR TITLE
Add windows target and clean

### DIFF
--- a/gitignore.example
+++ b/gitignore.example
@@ -7,6 +7,7 @@
 /.push*
 /linux
 /darwin
+/windows
 /.dockerfile
 /VERSION.txt
 /.docker_image

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -30,7 +30,7 @@ LDFLAGS := -extldflags -static $(VERSION_LDFLAGS)
 
 build: linux darwin
 
-linux darwin: $(GOFILES)
+linux darwin windows: $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)"
 	@rm -f VERSION.txt
 	@mkdir -p bin/$@ .go/std/$@ .go/bin .go/src/$(PKG)
@@ -139,7 +139,7 @@ version:
 clean: container-clean bin-clean
 
 container-clean:
-	rm -rf .container-* .dockerfile* .push-* linux darwin container VERSION.txt .docker_image
+	rm -rf .container-* .dockerfile* .push-* linux darwin windows container VERSION.txt .docker_image
 
 bin-clean:
 	rm -rf .go bin .tmp

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -38,8 +38,9 @@ func TestBuild(t *testing.T) {
 
 	// Map OS name to output location
 	binlocs := map[string]string{
-		"Darwin": "bin/darwin/darwin_amd64",
-		"Linux":  "bin/linux",
+		"Darwin":  "bin/darwin/darwin_amd64/build_tools_dummy",
+		"Linux":   "bin/linux/build_tools_dummy",
+		"Windows": "bin/windows/windows_amd64/build_tools_dummy.exe",
 	}
 
 	dir, _ := os.Getwd()
@@ -70,8 +71,12 @@ func TestBuild(t *testing.T) {
 	a.NoError(err)
 	a.Contains(string(v), "building linux")
 
+	v, err = exec.Command("make", "windows").Output()
+	a.NoError(err)
+	a.Contains(string(v), "building windows")
+
 	// Run the native gofmtproblem application to make sure it runs
-	v, err = exec.Command(binlocs[osname] + "/build_tools_dummy").Output()
+	v, err = exec.Command(binlocs[osname]).Output()
 	a.NoError(err)
 	a.Contains(string(v), "This is build_tools_dummy.go")
 	a.Contains(string(v), version.VERSION)


### PR DESCRIPTION
## The Problem:

We're flirting with Windows support for ddev, and it's easy enough to *build* for windows. Add the target and clean.

## The Fix:

Ad the target and clean.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

