### PR TITLE
Add missing backslash in base_test_go

### DIFF
--- a/makefile_components/base_test_go.mak
+++ b/makefile_components/base_test_go.mak
@@ -15,7 +15,7 @@ test: build
 	    -v $$(pwd)/bin/linux:/go/bin                                     \
 	    -v $$(pwd)/.go/std/linux:/usr/local/go/pkg/linux_amd64_static  \
 	    -e CGO_ENABLED=0	\
-	    -e GOOS=$$(uname -s |  tr "[:upper:]" "[:lower:]")
+	    -e GOOS=$$(uname -s |  tr "[:upper:]" "[:lower:]") \
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
         go test -v -installsuffix static -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER)


### PR DESCRIPTION
## The Problem:

A backslash was tragically lost, breaking the default `make test` behavior for golang building.

## The Fix:

Add the backslash back

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

