### PR TITLE
Remove inappropriate GOOS statement since we can't cross-compile test

### DIFF
--- a/makefile_components/base_test_go.mak
+++ b/makefile_components/base_test_go.mak
@@ -15,7 +15,6 @@ test: build
 	    -v $$(pwd)/bin/linux:/go/bin                                     \
 	    -v $$(pwd)/.go/std/linux:/usr/local/go/pkg/linux_amd64_static  \
 	    -e CGO_ENABLED=0	\
-	    -e GOOS=$$(uname -s |  tr "[:upper:]" "[:lower:]") \
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
         go test -v -installsuffix static -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -57,6 +57,7 @@ test: build
 	@mkdir -p bin/linux
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
 	go test -v -installsuffix "static" -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER) $(TESTARGS)
+	$(MAKE) -C standard_target $@
 
 # Simple way to execute a random command in the container for tests - used only for testing
 # Example: make COMMAND="govendor fetch golang.org/x/net/context"

--- a/tests/standard_target/.gitignore
+++ b/tests/standard_target/.gitignore
@@ -1,3 +1,5 @@
+# Add these lines to the .gitignore in each directory with a Makefile
+
 # Temporary build-tools artifacts to be ignored
 /.go/
 /bin/

--- a/tests/standard_target/Makefile
+++ b/tests/standard_target/Makefile
@@ -1,0 +1,53 @@
+# Makefile for a standard repo with associated container
+
+##### These variables need to be adjusted in most repositories #####
+
+# This repo's root import path (under GOPATH).
+PKG := github.com/drud/build-tools/tests/standard_target/cmd
+
+# Docker repo for a push
+# DOCKER_REPO ?= drud/docker_repo_name
+
+# Upstream repo used in the Dockerfile
+# UPSTREAM_REPO ?= full/upstream-docker-repo
+
+# Top-level directories to build
+SRC_DIRS := cmd
+
+# Version variables to replace in build, The variable VERSION is automatically pulled from git committish so it doesn't have to be added
+# These are replaced in the $(PKG).version package.
+# VERSION_VARIABLES = ThisCmdVersion ThatContainerVersion
+
+# These variables will be used as the defaults unless overridden by the make command line
+#ThisCmdVersion ?= $(VERSION)
+#ThatContainerVersion ?= drud/nginx-php-fpm7-local
+
+# Optional to docker build
+# DOCKER_ARGS =
+
+# VERSION can be set by
+  # Default: git tag
+  # make command line: make VERSION=0.9.0
+# It can also be explicitly set in the Makefile as commented out below.
+
+# This version-strategy uses git tags to set the version string
+# VERSION can be overridden on make commandline: make VERSION=0.9.1 push
+VERSION := $(shell git describe --tags --always --dirty)
+#
+# This version-strategy uses a manual value to set the version string
+#VERSION := 1.2.3
+
+# Each section of the Makefile is included from standard components below.
+# If you need to override one, import its contents below and comment out the
+# include. That way the base components can easily be updated as our general needs
+# change.
+include ../../makefile_components/base_build_go.mak
+#include build-tools/makefile_components/base_build_python-docker.mak
+include ../../makefile_components/base_container.mak
+include ../../makefile_components/base_push.mak
+include ../../makefile_components/base_test_go.mak
+#include build-tools/makefile_components/base_test_python.mak
+
+
+# Additional targets can be added here
+# Also, existing targets can be overridden by copying and customizing them.

--- a/tests/standard_target/cmd/main.go
+++ b/tests/standard_target/cmd/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("This is just a silly main.")
+}

--- a/tests/standard_target/cmd/main_test.go
+++ b/tests/standard_target/cmd/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestSomething(t *testing.T) {
+	t.Log("Yup, this is working")
+}


### PR DESCRIPTION
## The Problem:

Over in 8e7d62f2 https://github.com/drud/build-tools/pull/21 I made a silly edit to the default test target which completely broke lots of things. You can't set $GOOS for a test, because you'll get crazy errors like this:

```
fork/exec /tmp/go-build380509523/github.com/drud/elysium/pkg/elysium/_test/elysium.test: exec format error
FAIL	github.com/drud/elysium/pkg/elysium	0.009s
```
Go test has to run what it compiles on the environment it compiled for, not something else. We were trying to test darwin build on a linux machine.

## The Fix:

Remove the GOOS setting from the default golang test target.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

