### PR TITLE
Upgrade to golang 1.8.3

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.4.1
+BUILD_IMAGE ?= drud/golang-build-container:v0.4.2_provisional
 
 BUILD_BASE_DIR ?= $$PWD
 

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.4.2_provisional
+BUILD_IMAGE ?= drud/golang-build-container:v0.4.2
 
 BUILD_BASE_DIR ?= $$PWD
 


### PR DESCRIPTION
## The Problem:

golang has moved along to v1.8.3 - there's not a lot of change, but it's worth keeping up.

## The Fix:

Upgrade.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

https://github.com/drud/golang-build-container/pull/5 is the upgrade for golang-build-container. It needs to be tagged, then this one can be tagged with another commit and we'll be there.

## Release/Deployment notes:

This is currently using the provisional tag (manually pushed). When the real push is done from a tagged release on golang_build_container then we can just add a commit to this with the real tag, then create a release.

