### PR TITLE
Step away from using .go since dep will use it, fixes #11

### DIFF
--- a/gitignore.example
+++ b/gitignore.example
@@ -2,6 +2,7 @@
 
 # Temporary build-tools artifacts to be ignored
 /.go/
+/.gotmp/
 /bin/
 /.container*
 /.push*

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -6,6 +6,7 @@
 
 
 .PHONY: all build test push clean container-clean bin-clean version static govendor gofmt govet golint
+GOTMP=.gotmp
 
 SHELL := /bin/bash
 
@@ -35,13 +36,14 @@ build: linux darwin
 linux darwin windows: $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)"
 	@rm -f VERSION.txt
-	@mkdir -p bin/$@ .go/std/$@ .go/bin .go/src/$(PKG)
+	@mkdir -p bin/$@ $(GOTMP)/{std/$@,bin,src/$(PKG)}
+
 	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
-	    -v $$(pwd)/.go:/go                                                 \
+	    -v $$(pwd)/$(GOTMP):/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/$@:/go/bin                                     \
 	    -v $$(pwd)/bin/$@:/go/bin/$@                      \
-	    -v $$(pwd)/.go/std/$@:/usr/local/go/pkg/$@_amd64_static  \
+	    -v $$(pwd)/$(GOTMP)/std/$@:/usr/local/go/pkg/$@_amd64_static  \
 	    -e CGO_ENABLED=0                  \
 	    -e GOOS=$@						  \
 	    -w /go/src/$(PKG)                 \
@@ -55,7 +57,7 @@ static: govendor gofmt govet lint
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -64,7 +66,7 @@ govendor:
 gofmt:
 	@echo "Checking gofmt: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -73,7 +75,7 @@ gofmt:
 govet:
 	@echo "Checking go vet: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -82,7 +84,7 @@ govet:
 golint:
 	@echo "Checking golint: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -91,7 +93,7 @@ golint:
 errcheck:
 	@echo "Checking errcheck: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -100,7 +102,7 @@ errcheck:
 staticcheck:
 	@echo "Checking staticcheck: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -109,7 +111,7 @@ staticcheck:
 unused:
 	@echo "Checking unused variables and functions: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -118,7 +120,7 @@ unused:
 codecoroner:
 	@echo "Checking codecoroner for unused functions: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE) \
@@ -128,7 +130,7 @@ codecoroner:
 varcheck:
 	@echo "Checking unused globals and struct members: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -137,7 +139,7 @@ varcheck:
 misspell:
 	@echo "Checking for misspellings: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -146,7 +148,7 @@ misspell:
 gometalinter:
 	@echo "gometalinter: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
@@ -161,7 +163,7 @@ container-clean:
 	rm -rf .container-* .dockerfile* .push-* linux darwin windows container VERSION.txt .docker_image
 
 bin-clean:
-	rm -rf .go bin .tmp
+	rm -rf $(GOTMP) bin .tmp
 
 # print-ANYVAR prints the expanded variable
 print-%: ; @echo $* = $($*)

--- a/makefile_components/base_build_python-docker.mak
+++ b/makefile_components/base_build_python-docker.mak
@@ -30,4 +30,4 @@ container-clean:
 	rm -rf .container-* .dockerfile* .push-* linux darwin container VERSION.txt .docker_image
 
 bin-clean:
-	rm -rf .go bin .tmp
+	rm -rf .go $(GOTMP) bin .tmp

--- a/makefile_components/base_test_go.mak
+++ b/makefile_components/base_test_go.mak
@@ -8,12 +8,12 @@ TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 test: build
 	@mkdir -p bin/linux
-	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
+	@mkdir -p $(GOTMP)/{src/$(PKG),pkg,bin,std/linux}
 	@docker run -t --rm  -u $(shell id -u):$(shell id -g)                 \
-	    -v $$(pwd)/.go:/go                                                 \
+	    -v $$(pwd)/$(GOTMP):/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/linux:/go/bin                                     \
-	    -v $$(pwd)/.go/std/linux:/usr/local/go/pkg/linux_amd64_static  \
+	    -v $$(pwd)/$(GOTMP)/std/linux:/usr/local/go/pkg/linux_amd64_static  \
 	    -e CGO_ENABLED=0	\
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,5 +1,6 @@
 # Temporary build-tools artifacts to be ignored
 /.go/
+/.gotmp/
 /bin/
 /.container*
 /.push*

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,7 +55,7 @@ include ../makefile_components/base_push.mak
 # golang compiler container.
 test: build
 	@mkdir -p bin/linux
-	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
+	@mkdir -p  $(GOTMP)/{src/$(PKG),pkg,bin,std/linux}
 	go test -v -installsuffix "static" -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER) $(TESTARGS)
 	$(MAKE) -C standard_target $@
 
@@ -66,7 +66,7 @@ container_cmd:
 	@docker run                                                            \
 		-t                                                                \
 	    -u $(shell id -u):$(shell id -g)                                             \
-		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd)/$(GOTMP):/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \

--- a/tests/standard_target/.gitignore
+++ b/tests/standard_target/.gitignore
@@ -2,6 +2,7 @@
 
 # Temporary build-tools artifacts to be ignored
 /.go/
+/.gotmp/
 /bin/
 /.container*
 /.push*


### PR DESCRIPTION
## The Problem:

The up-and-coming golang dep tool, which will solve most of the world's problems, appears to use .go, which conflicts with our usage. We'd like to step out of the way.

## The Fix:

Parameterize the tmp .go directory, and then handle it. It becomes .gotmp

## The Test:

Should be fine if it passes existing tests.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

Fixes #11

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

