### PR TITLE
Quiet builds - we don't need to see docker any more

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -38,7 +38,7 @@ linux darwin windows: $(GOFILES)
 	@rm -f VERSION.txt
 	@mkdir -p bin/$@ $(GOTMP)/{std/$@,bin,src/$(PKG)}
 
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 	    -v $$(pwd)/$(GOTMP):/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/$@:/go/bin                                     \


### PR DESCRIPTION
## The Problem:

When we were getting used to build-tools we had the full make build output going on, and it's a doozie, with all that docker nonsense.

We don't need to see all that any more.

## The Fix:

Put an @ in front of the build command.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

