### PR TITLE
Remove .circleci on install

### DIFF
--- a/build_update.sh
+++ b/build_update.sh
@@ -40,7 +40,7 @@ tar -xf $local_file
 rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
-rm -rf build-tools/tests/ build-tools/circle.yml build-tools/.github
+rm -rf build-tools/{tests,circle.yml,.circleci,.github}
 touch build-tools/build-tools-VERSION-$tag.txt
 git add build-tools
 echo "Updated build-tools to $tag


### PR DESCRIPTION
## The Problem:

When circle.yml moved to .circleci, build-tools didn't catch it, so build-tools' own .circleci folder is not being deleted on install.

## The Fix:

Add it to the removal in the script.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

