### PR TITLE
Add test_precompile target to compile but not run tests

### DIFF
--- a/makefile_components/base_test_go.mak
+++ b/makefile_components/base_test_go.mak
@@ -9,6 +9,7 @@ TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 test: build
 	@mkdir -p bin/linux
 	@mkdir -p $(GOTMP)/{src/$(PKG),pkg,bin,std/linux}
+	@echo "Testing $(SRC_AND_UNDER) with TESTARGS=$(TESTARGS)"
 	@docker run -t --rm  -u $(shell id -u):$(shell id -g)                 \
 	    -v $$(pwd)/$(GOTMP):/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
@@ -17,4 +18,9 @@ test: build
 	    -e CGO_ENABLED=0	\
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
-        go test -v -installsuffix static -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER)
+        go test -v -installsuffix static -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER) $(TESTARGS)
+
+# test_precompile allows a full compilation of _test.go files, without execution of the tests.
+# Setup and teardown in TestMain is still executed though, so this can cost some time.
+test_precompile: TESTARGS=-run '^$$'
+test_precompile: test

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -56,8 +56,13 @@ include ../makefile_components/base_push.mak
 test: build
 	@mkdir -p bin/linux
 	@mkdir -p  $(GOTMP)/{src/$(PKG),pkg,bin,std/linux}
-	go test -v -installsuffix "static" -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER) $(TESTARGS)
+	@go test -v -installsuffix "static" -ldflags '$(LDFLAGS)' $(SRC_AND_UNDER) $(TESTARGS)
 	$(MAKE) -C standard_target $@
+
+# test_precompile allows a full compilation of _test.go files, without execution of the tests.
+# Setup and teardown in TestMain is still executed though, so this can cost some time.
+test_precompile: TESTARGS=-run '^$$'
+test_precompile: test
 
 # Simple way to execute a random command in the container for tests - used only for testing
 # Example: make COMMAND="govendor fetch golang.org/x/net/context"


### PR DESCRIPTION
## The Problem:

Our tests can have outright syntax errors in them, but we don't find out about it until we do a full test run, as each package's tests are only compiled when its tests are run. This is particularly painful when doing a large-ish refactor and you make little mistakes with imports and such, but don't find out until a full test.

## The Fix:

This adds a test_precompile target (`make test_precompile`) which easily builds all the tests without running them. However, all code in TestMain gets run so it can slow things down. The test_precompile time for ddev is almost a minute.

**Note: This is already easily available in (almost?) all usages of build-tools with `make test TESTARGS='-run "^$$"'`**

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

