### PR TITLE
We shouldn't be using gcloud to push to docker

### DIFF
--- a/makefile_components/base_push.mak
+++ b/makefile_components/base_push.mak
@@ -6,7 +6,7 @@
 
 push: .push-$(DOTFILE_IMAGE) push-name
 .push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
-	@gcloud docker -- push $(DOCKER_REPO):$(VERSION)
+	docker push $(DOCKER_REPO):$(VERSION)
 	@docker images -q $(DOCKER_REPO):$(VERSION) > $@
 
 push-name:


### PR DESCRIPTION
## The Problem:

It seems the push component was using gcloud to push to docker. Not should be that way.

## The Fix:

Just use docker.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

