### PR TITLE
add docker image push on new tag to circle example

### DIFF
--- a/circleci-config-yaml.example
+++ b/circleci-config-yaml.example
@@ -18,3 +18,18 @@ stages:
 
       - run: make -s gofmt golint
 
+      - deploy:
+          name: push docker image on new tag push
+          command: |
+            CURRENT_TAG=$(git describe --tags --abbrev=0)
+            COMMIT_TAG=$(git describe --tags)
+            if [ "${CURRENT_TAG}" == "${COMMIT_TAG}" ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              make push
+            fi
+
+# workaround for triggering a build when new tag is pushed
+# https://discuss.circleci.com/t/git-tag-deploys-in-2-0/9493/8
+deployment:
+  push_on_tag:
+    tag: /.*/


### PR DESCRIPTION
## The Problem:
We currently push docker images manually from local systems when we tag a new release. It would be great to not do that.

## The Fix:
This introduces configuration for CircleCI that can be used for building and pushing an image to docker hub when a new tag is pushed. Circle 2 does not yet provide proper support for building on tag pushes, so it uses a workaround provided by CircleCI to trigger the build when a new tag is pushed. They do plan to properly support this functionality in the future, but no timeline has been provided at this point.

**Note:** This should only be used on CircleCI projects with the "Pass secrets to builds from forked pull requests" option in the project's Advanced Settings turned Off. Ensuring this option is disabled will ensure that untrusted forks can not retrieve credentials for docker.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

