### PR TITLE
replace static target with gometalinter, update circle cfg example to use it

### DIFF
--- a/circleci-config-yaml.example
+++ b/circleci-config-yaml.example
@@ -16,5 +16,5 @@ stages:
 
       - run: make test
 
-      - run: make -s static
+      - run: make -s gometalinter
 

--- a/circleci-config-yaml.example
+++ b/circleci-config-yaml.example
@@ -16,5 +16,5 @@ stages:
 
       - run: make test
 
-      - run: make -s gofmt golint
+      - run: make -s static
 

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -21,7 +21,7 @@ BUILD_BASE_DIR ?= $$PWD
 # Expands SRC_DIRS into the common golang ./dir/... format for "all below"
 SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
 
-GOMETALINTER_ARGS ?= --vendored-linters --disable-all --enable=gofmt --enable=vet --enable=golint --enable=errcheck --enable=staticcheck --deadline=2m
+GOMETALINTER_ARGS ?= --vendored-linters --disable-all --enable=gofmt --enable=vet --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode --deadline=2m
 
 
 COMMIT := $(shell git describe --tags --always --dirty)

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -59,7 +59,7 @@ linux darwin windows: $(GOFILES)
 	@$(shell touch $@)
 	@echo $(VERSION) >VERSION.txt
 
-static: govendor gofmt govet lint
+static: gofmt govet golint errcheck staticcheck codecoroner
 
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -21,7 +21,7 @@ BUILD_BASE_DIR ?= $$PWD
 # Expands SRC_DIRS into the common golang ./dir/... format for "all below"
 SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
 
-GOMETALINTER_ARGS ?= --vendored-linters --disable=gocyclo --disable=gotype --disable=goconst --disable=gas --deadline=2m
+GOMETALINTER_ARGS ?= --vendored-linters --disable-all --enable=gofmt --enable=vet --enable=golint --enable=errcheck --enable=staticcheck --deadline=2m
 
 
 COMMIT := $(shell git describe --tags --always --dirty)
@@ -58,8 +58,6 @@ linux darwin windows: $(GOFILES)
         go install -installsuffix static -ldflags ' $(LDFLAGS) ' $(SRC_AND_UNDER)
 	@$(shell touch $@)
 	@echo $(VERSION) >VERSION.txt
-
-static: gofmt govet golint errcheck staticcheck codecoroner
 
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -257,8 +257,10 @@ func TestGoMetalinter(t *testing.T) {
 
 	// Test "make gometalinter"
 	v, err := exec.Command("make", "gometalinter").Output()
-	a.Error(err)                                                  // Should complain about pretty much everything in the dirtyComplex package.
-	a.Contains(string(v), "yetAnotherExportedFunction is unused") // Check an unexported function.
+	a.Error(err) // Should complain about pretty much everything in the dirtyComplex package.
+	a.Contains(string(v), "exported function DummyExported_function should have comment or be unexported (golint)")
+	a.Contains(string(v), "file is not gofmted with -s (gofmt)")
+	a.Contains(string(v), "this value of err is never used (SA4006) (staticcheck)")
 
 	// Test "make SRC_DIRS=pkg/clean codecoroner" to limit to just clean directories
 	_, err = exec.Command("make", "gometalinter", "SRC_DIRS=pkg/clean").Output()


### PR DESCRIPTION
## The Problem:
We have a nice ['staticrequired' target added to ddev](https://github.com/drud/ddev/blob/master/Makefile#L92). We should run those tools in the 'static' target provided by build-tools, and update the example circle config to use the static target instead of calling tool-specific targets. This should help ensure new go projects get the same testing treatment that ddev and others have been set up with.

## The Fix:
This does that.
## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

