### PR TITLE
Remove hard-wired VERSION from Makefile.example as git-tied VERSION serves well

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -8,11 +8,11 @@ PKG := github.com/drud/repo_name
 # Docker repo for a push
 # DOCKER_REPO ?= drud/docker_repo_name
 
-# Upstream repo used in the Dockerfile
+# Upstream repo optionally used in the Dockerfile
 # UPSTREAM_REPO ?= full/upstream-docker-repo
 
 # Top-level directories to build
-SRC_DIRS := files drudapi secrets utils
+SRC_DIRS := pkg cmd
 
 # Version variables to replace in build, The variable VERSION is automatically pulled from git committish so it doesn't have to be added
 # These are replaced in the $(PKG).version package.
@@ -30,12 +30,11 @@ SRC_DIRS := files drudapi secrets utils
   # make command line: make VERSION=0.9.0
 # It can also be explicitly set in the Makefile as commented out below.
 
-# This version-strategy uses git tags to set the version string
-# VERSION can be overridden on make commandline: make VERSION=0.9.1 push
+# Normally VERSION is derived from git committish/tag.
+# VERSION can be overridden on make commandline: make push VERSION=0.9.1
+# Using the git committish means we can always tie code to container or binary.
 VERSION := $(shell git describe --tags --always --dirty)
-#
-# This version-strategy uses a manual value to set the version string
-#VERSION := 1.2.3
+
 
 # Each section of the Makefile is included from standard components below.
 # If you need to override one, import its contents below and comment out the
@@ -49,5 +48,5 @@ include build-tools/makefile_components/base_test_go.mak
 #include build-tools/makefile_components/base_test_python.mak
 
 
-# Additional targets can be added here
+# Additional targets can be added below.
 # Also, existing targets can be overridden by copying and customizing them.


### PR DESCRIPTION
## The Problem:

Originally, the Makefile.example gave hard-wired in-Makefile VERSION hint, but we normally really really want to tie VERSION to git version/tag except when making rapid changes, when it can be overridden on the command line.


## The Fix:

This just removes the suggestion of a fixed VERSION in the Makefile. It does some trivial cleanup of example and comment along the way.


## The Test:

This changes nothing, just the example.


