### PR TITLE
Add docker mount flag :delegated to mounts

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -32,6 +32,7 @@ VERSION_VARIABLES += VERSION COMMIT BUILDINFO
 VERSION_LDFLAGS := $(foreach v,$(VERSION_VARIABLES),-X "$(PKG)/pkg/version.$(v)=$($(v))")
 
 LDFLAGS := -extldflags -static $(VERSION_LDFLAGS)
+DOCKERMOUNTFLAG := $(DOCKERMOUNTFLAG)
 
 PWD=$(shell pwd)
 ifeq ($(BUILD_OS),windows)
@@ -46,11 +47,11 @@ linux darwin windows: $(GOFILES)
 	@$(shell rm -f VERSION.txt)
 	@$(shell mkdir -p bin/$@ $(GOTMP)/{std/$@,bin,src/$(PKG)})
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
-	    -v $(PWD)/$(GOTMP):/go                                                 \
-	    -v $(PWD):/go/src/$(PKG)                                          \
-	    -v $(PWD)/bin/$@:/go/bin                                     \
-	    -v $(PWD)/bin/$@:/go/bin/$@                      \
-	    -v $(PWD)/$(GOTMP)/std/$@:/usr/local/go/pkg/$@_amd64_static  \
+	    -v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                   \
+	    -v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                 \
+	    -v $(PWD)/bin/$@:/go/bin$(DOCKERMOUNTFLAG)                         \
+	    -v $(PWD)/bin/$@:/go/bin/$@$(DOCKERMOUNTFLAG)                 \
+	    -v $(PWD)/$(GOTMP)/std/$@:/usr/local/go/pkg/$@_amd64_static$(DOCKERMOUNTFLAG)  \
 	    -e CGO_ENABLED=0                  \
 	    -e GOOS=$@						  \
 	    -w /go/src/$(PKG)                 \
@@ -62,17 +63,17 @@ linux darwin windows: $(GOFILES)
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                   \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                  \
+		-w /go/src/$(PKG)                                         \
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'OUT=$$(govendor list +missing +unused); if [ -n "$$OUT" ]; then echo "$$OUT"; exit 1; fi'
 
 gofmt:
 	@echo "Checking gofmt: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'export OUT=$$(gofmt -l $(SRC_DIRS))  && if [ -n "$$OUT" ]; then echo "These files need gofmt -w: $$OUT"; exit 1; fi'
@@ -80,8 +81,8 @@ gofmt:
 govet:
 	@echo "Checking go vet: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'go vet $(SRC_AND_UNDER)'
@@ -89,8 +90,8 @@ govet:
 golint:
 	@echo "Checking golint: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'export OUT=$$(golint $(SRC_AND_UNDER)) && if [ -n "$$OUT" ]; then echo "Golint problems discovered: $$OUT"; exit 1; fi'
@@ -98,8 +99,8 @@ golint:
 errcheck:
 	@echo "Checking errcheck: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		errcheck $(SRC_AND_UNDER)
@@ -107,8 +108,8 @@ errcheck:
 staticcheck:
 	@echo "Checking staticcheck: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		staticcheck $(SRC_AND_UNDER)
@@ -116,8 +117,8 @@ staticcheck:
 unused:
 	@echo "Checking unused variables and functions: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		unused $(SRC_AND_UNDER)
@@ -125,8 +126,8 @@ unused:
 codecoroner:
 	@echo "Checking codecoroner for unused functions: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE) \
 		bash -c 'OUT=$$(codecoroner -tests -ignore vendor funcs $(SRC_AND_UNDER)); if [ -n "$$OUT" ]; then echo "$$OUT"; exit 1; fi'                                             \
@@ -135,8 +136,8 @@ codecoroner:
 varcheck:
 	@echo "Checking unused globals and struct members: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		varcheck $(SRC_AND_UNDER) && structcheck $(SRC_AND_UNDER)
@@ -144,8 +145,8 @@ varcheck:
 misspell:
 	@echo "Checking for misspellings: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		misspell $(SRC_DIRS)
@@ -153,8 +154,8 @@ misspell:
 gometalinter:
 	@echo "gometalinter: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go                                                 \
-		-v $(PWD):/go/src/$(PKG)                                          \
+		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		gometalinter $(GOMETALINTER_ARGS) $(SRC_AND_UNDER)

--- a/makefile_components/base_test_go.mak
+++ b/makefile_components/base_test_go.mak
@@ -11,10 +11,10 @@ test: build
 	@mkdir -p $(GOTMP)/{src/$(PKG),pkg,bin,std/linux}
 	@echo "Testing $(SRC_AND_UNDER) with TESTARGS=$(TESTARGS)"
 	@docker run -t --rm  -u $(shell id -u):$(shell id -g)                 \
-	    -v $(PWD)/$(GOTMP):/go                                                 \
-	    -v $(PWD):/go/src/$(PKG)                                          \
-	    -v $(PWD)/bin/linux:/go/bin                                     \
-	    -v $(PWD)/$(GOTMP)/std/linux:/usr/local/go/pkg/linux_amd64_static  \
+	    -v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+	    -v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+	    -v $(PWD)/bin/linux:/go/bin$(DOCKERMOUNTFLAG)                                     \
+	    -v $(PWD)/$(GOTMP)/std/linux:/usr/local/go/pkg/linux_amd64_static$(DOCKERMOUNTFLAG)  \
 	    -e CGO_ENABLED=0	\
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \


### PR DESCRIPTION
## The Problem:

Big builds were taking way long. The most likely culprit was the performance of the mount. But since we only care about what's in the container during the build, we can use the :delegated flag.

This adds the :delegated flag to mounts on the golang-build-container

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

