### PR TITLE
Upgrade golang-build-container to v0.5.1-golang 1.9.1

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -14,7 +14,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.0
+BUILD_IMAGE ?= drud/golang-build-container:v0.5.1
 
 BUILD_BASE_DIR ?= $$PWD
 


### PR DESCRIPTION
## The Problem:

We've bumped the golang-build-container to v0.5.1 to get golang 1.9.1

This is a one-character PR :)

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

