### PR TITLE
Actually use the docker mount :delegated flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 stages:
   build:
-    machine: true
+    machine:
+      image: circleci/classic:201708-01
     working_directory: /home/circleci/go/src/github.com/drud/build-tools
 
     environment:

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -32,7 +32,7 @@ VERSION_VARIABLES += VERSION COMMIT BUILDINFO
 VERSION_LDFLAGS := $(foreach v,$(VERSION_VARIABLES),-X "$(PKG)/pkg/version.$(v)=$($(v))")
 
 LDFLAGS := -extldflags -static $(VERSION_LDFLAGS)
-DOCKERMOUNTFLAG := $(DOCKERMOUNTFLAG)
+DOCKERMOUNTFLAG := :delegated
 
 PWD=$(shell pwd)
 ifeq ($(BUILD_OS),windows)


### PR DESCRIPTION
## The Problem:

In https://github.com/drud/build-tools/pull/46 I added the structure for providing a docker mount flag (:delegated) but failed to actually supply it. This fixes that fail. Glad you caught it Tanner even though my trigger finger was too fast.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

