### PR TITLE
update Makefile.example to indent with tabs

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -26,9 +26,8 @@ SRC_DIRS := pkg cmd
 # DOCKER_ARGS =
 
 # VERSION can be set by
-  # Default: git tag
-  # make command line: make VERSION=0.9.0
-# It can also be explicitly set in the Makefile as commented out below.
+	# Default: git tag
+	# make command line: make VERSION=0.9.0
 
 # Normally VERSION is derived from git committish/tag.
 # VERSION can be overridden on make commandline: make push VERSION=0.9.1


### PR DESCRIPTION
## The Problem:
Just a little thing to hopefully avoid trouble down the road setting up project makefiles from the example. An indentation in our example makefile causes editors to detect 2-space indentation, when we want tabs instead for makefiles.
 
## The Fix:
Converted indentation to tabs in example.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

