### PR TITLE
Bump golang-build-container to pick up go 1.9.3

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -14,7 +14,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.1
+BUILD_IMAGE ?= drud/golang-build-container:v0.5.2
 
 BUILD_BASE_DIR ?= $$PWD
 

--- a/makefile_components/base_build_python-docker.mak
+++ b/makefile_components/base_build_python-docker.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 PWD := $(shell pwd)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.2.0
+BUILD_IMAGE ?= drud/golang-build-container:v0.5.2
 
 all: VERSION.txt build
 


### PR DESCRIPTION
## The Problem:

It's time to bump golang and update the build container. https://github.com/drud/golang-build-container/pull/10

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

After the golang build container patch goes in, this one has to be updated with the real released image. https://github.com/drud/golang-build-container/pull/10