### PR TITLE
updates golang-build-container to v0.5.4

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -14,7 +14,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.3
+BUILD_IMAGE ?= drud/golang-build-container:v0.5.4
 
 BUILD_BASE_DIR ?= $$PWD
 

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -14,7 +14,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.2
+BUILD_IMAGE ?= drud/golang-build-container:v0.5.3
 
 BUILD_BASE_DIR ?= $$PWD
 

--- a/makefile_components/base_build_python-docker.mak
+++ b/makefile_components/base_build_python-docker.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 PWD := $(shell pwd)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.3
+BUILD_IMAGE ?= drud/golang-build-container:v0.5.4
 
 all: VERSION.txt build
 

--- a/makefile_components/base_build_python-docker.mak
+++ b/makefile_components/base_build_python-docker.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 PWD := $(shell pwd)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.2
+BUILD_IMAGE ?= drud/golang-build-container:v0.5.3
 
 all: VERSION.txt build
 


### PR DESCRIPTION
## The Problem:
This updates build-tools to use v0.5.4 of the golang-build-container, which adds dep and glide dependency management tools.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

