### PR TITLE
Upgrade build-tools for golang 1.10, clear cache on clean

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,17 @@ version: 2
 stages:
   build:
     machine:
-      image: circleci/classic:201708-01
+      image: circleci/classic:201711-01
     working_directory: /home/circleci/go/src/github.com/drud/build-tools
 
     environment:
       GOPATH: /home/circleci/go
 
     steps:
+      - run: sudo rm -rf /usr/local/go &&
+             wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.linux-amd64.tar.gz &&
+             sudo tar -C /usr/local -xzf /tmp/golang.tgz
+
       - run: mkdir -p ~/go/src/github.com/drud/build-tools && mkdir -p ~/go/lib && mkdir -p ~/go/bin
 
       - checkout

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -14,7 +14,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.4
+BUILD_IMAGE ?= drud/golang-build-container:v0.5.5
 
 BUILD_BASE_DIR ?= $$PWD
 
@@ -164,6 +164,7 @@ version:
 	@echo VERSION:$(VERSION)
 
 clean: container-clean bin-clean
+	go clean -cache || echo "You're not running latest golang locally" # Make sure the local go cache is clean for testing
 
 container-clean:
 	$(shell rm -rf .container-* .dockerfile* .push-* linux darwin windows container VERSION.txt .docker_image)


### PR DESCRIPTION
## The Problem:

The golang-build-container is being upgraded to golang 1.10. This pulls that in.

In addition, since go 1.10 has far more aggressive caching, it's important to clear the *local* go cache on `make clean`. The local go is used for testing at least on ddev, so its caching sometimes really needs to go away.

Followup:
- [ ] Actually make the BUILD_IMAGE the one that has been released upstream instead of the temporary image referenced here.
- [ ] Make a new release
- [ ] Upgrade downstream projects as needed.