### PR TITLE
Remove BUILD_IMAGE from python-docker as it's not used

### DIFF
--- a/makefile_components/base_build_python-docker.mak
+++ b/makefile_components/base_build_python-docker.mak
@@ -11,8 +11,6 @@ SHELL := /bin/bash
 
 PWD := $(shell pwd)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.4
-
 all: VERSION.txt build
 
 build: linux


### PR DESCRIPTION
## The Problem:

We keep forgetting to update BUILD_IMAGE in docker-python build... but we don't even use it there. 

Remove it from that spot. I'm pretty sure it will do no harm.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

