### PR TITLE
Quiet the normal build, shouldn't be emitting the whole docker build

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -49,7 +49,7 @@ linux darwin windows: $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)"
 	@$(shell rm -f VERSION.txt)
 	@$(shell mkdir -p bin/$@ $(GOTMP)/{std/$@,bin,src/$(PKG)})
-	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 	    -v "$(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)"                                \
 	    -v "$(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)"                              \
 	    -v "$(S)$$PWD/bin/$@:/go/bin$(DOCKERMOUNTFLAG)"                        \


### PR DESCRIPTION
## The Problem:

I left an '@' out of the main build command, so now `make` emits all kinds of output I didn't want to see. 

## The Fix:

Put the @ back in.

## The Test:

Do a `make`. You should see a little, not a lot.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

