### PR TITLE
Fix container build so make push will work again

### DIFF
--- a/makefile_components/base_container.mak
+++ b/makefile_components/base_container.mak
@@ -8,7 +8,9 @@ SANITIZED_DOCKER_REPO = $(subst /,_,$(DOCKER_REPO))
 
 DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
 
-container: $(wildcard Dockerfile*)
+container: .container-$(DOTFILE_IMAGE) container-name
+
+.container-$(DOTFILE_IMAGE): $(wildcard Dockerfile Dockerfile.in) container-name
     # UPSTREAM_REPO in the Dockerfile.in will be changed to the value from Makefile; this is deprecated.
     # There's no reason not to just use Dockerfile now.
 	@if [ -f Dockerfile.in ]; then sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile; else cp Dockerfile .dockerfile; fi
@@ -17,8 +19,7 @@ container: $(wildcard Dockerfile*)
 	# Add the .docker_image into the build so it's easy to figure out where a docker image came from.
 	@echo "ADD .docker_image /$(SANITIZED_DOCKER_REPO)_VERSION_INFO.txt" >>.dockerfile
 	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) -f .dockerfile .
-	@docker images -q $(DOCKER_REPO):$(VERSION) >/dev/null
-
+	@docker images -q $(DOCKER_REPO):$(VERSION) >$@
 
 container-name:
 	@echo "container: $(DOCKER_REPO):$(VERSION)"

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+RUN apk update && apk add git 
+
+# This is a dummy Dockerfile

--- a/tests/Dockerfile.in
+++ b/tests/Dockerfile.in
@@ -1,5 +1,0 @@
-FROM UPSTREAM_REPO
-
-RUN apk update && apk add git bash build-base
-
-# This is a dummy Dockerfile


### PR DESCRIPTION
## The Problem:

A regression in https://github.com/drud/build-tools/pull/56 broke `make push` by changing the artifacts in `make container`. 

## The Fix:

* Change it back to mostly what it was.
* In addition the container build test now uses Dockerfile instead of Dockerfile.in


## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

