### PR TITLE
Bump to golang v1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ stages:
 
     steps:
       - run: sudo rm -rf /usr/local/go &&
-             wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.10.linux-amd64.tar.gz &&
+             wget -q -O /tmp/golang.tgz https://dl.google.com/go/go1.11.linux-amd64.tar.gz &&
              sudo tar -C /usr/local -xzf /tmp/golang.tgz
 
       - run: mkdir -p ~/go/src/github.com/drud/build-tools && mkdir -p ~/go/lib && mkdir -p ~/go/bin

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -14,7 +14,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v1.10.3
+BUILD_IMAGE ?= drud/golang-build-container:v1.11
 
 BUILD_BASE_DIR ?= $$PWD
 

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -277,12 +277,13 @@ func TestGolangciLint(t *testing.T) {
 	// Test "make gometalinter"
 	v, err := exec.Command("make", "golangci-lint").Output()
 	a.Error(err) // Should complain about pretty much everything in the dirtyComplex package.
-	a.Contains(string(v), "don't use MixedCaps in package name; dirtyComplex should be dirtycomplex")
-	a.Contains(string(v), "don't use underscores in Go names; func DummyExported_function should be DummyExportedFunction (golint)")
-	a.Contains(string(v), "File is not gofmt-ed with -s (gofmt)")
-	a.Contains(string(v), "ineffectual assignment to `num` (ineffassign)")
-	a.Contains(string(v), "yetAnotherExportedFunction` is unused (deadcode)")
-	a.Contains(string(v), "Error return value of `os.Chown` is not checked (errcheck)")
+	execResult := string(v)
+	a.Contains(execResult, "don't use MixedCaps in package name; dirtyComplex should be dirtycomplex")
+	a.Contains(execResult, "don't use underscores in Go names; func DummyExported_function should be DummyExportedFunction (golint)")
+	a.Contains(execResult, "File is not `gofmt`-ed with `-s`")
+	a.Contains(execResult, "ineffectual assignment to `num` (ineffassign)")
+	a.Contains(execResult, "yetAnotherExportedFunction` is unused (deadcode)")
+	a.Contains(execResult, "Error return value of `os.Chown` is not checked (errcheck)")
 
 	out, err := exec.Command("make", "golangci-lint", "SRC_DIRS=pkg/clean").Output()
 	a.NoError(err, "Failed to get clean result for golangci-lint: %v (output=%s)", err, out) // Should have no complaints in clean package


### PR DESCRIPTION
## The Problem:

Golang v1.11 is out

## The Fix:

Bump to it (in golang-build-container)

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

