### PR TITLE
Forgot to USE_MOD_VENDOR in #61

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -12,12 +12,14 @@ DOCKERBUILDCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)              
           	    -e CGO_ENABLED=0                  \
           	    -e GOOS=$@						  \
           	    -e GOPATH="//workdir/$(GOTMP)" \
+          	    -e GOFLAGS="$(USEMODVENDOR)" \
           	    -w //workdir              \
           	    $(BUILD_IMAGE)
 
 DOCKERTESTCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
           	    -v "$(S)$(PWD):/workdir$(DOCKERMOUNTFLAG)"                              \
           	    -e GOPATH="//workdir/$(GOTMP)" \
+          	    -e GOFLAGS="$(USEMODVENDOR)" \
           	    -w //workdir              \
           	    $(BUILD_IMAGE)
 

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -23,7 +23,7 @@ DOCKERTESTCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)               
           	    -w //workdir              \
           	    $(BUILD_IMAGE)
 
-.PHONY: all build test push clean container-clean bin-clean version static gofmt govet golint golangci-lint container
+.PHONY: all build test push clean container-clean bin-clean version static gofmt govet golint golangci-lint container pull
 GOTMP=.gotmp
 
 SHELL = /bin/bash
@@ -75,8 +75,10 @@ ifneq ($(DOCKER_TOOLBOX_INSTALL_PATH),)
 endif
 
 build: $(BUILD_OS)
+
 pull:
-	@docker pull $(BUILD_IMAGE) >/dev/null 2>&1
+	@if [[ "$(docker images -q $(BUILD_IMAGE)  2> /dev/null)" == "" ]]; then docker pull $(BUILD_IMAGE) >/dev/null 2>&1; fi
+
 
 linux darwin windows: pull $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)"


### PR DESCRIPTION
## The Problem:

In #61 the use of $(USE_MOD_VENDOR) was dropped, meaning that a build will (successfully) download everything it (doesn't need) because it's already in vendor.

This also adds a test before pulling the build container, which should avoid unnecessary waiting.
