### PR TITLE
Bump golang to 1.12

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -32,7 +32,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v1.11.4.2
+BUILD_IMAGE ?= drud/golang-build-container:v1.12
 
 BUILD_BASE_DIR ?= $(PWD)
 

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -132,7 +132,6 @@ func TestGoVet(t *testing.T) {
 
 // Test errcheck.
 func TestErrCheck(t *testing.T) {
-	t.Skip("errcheck does not yet work with go 1.11 modules, see https://github.com/kisielk/errcheck/issues/155")
 	a := assert.New(t)
 
 	// pkg/dirtycomplex/bad_errcheck_code.go


### PR DESCRIPTION
## The Problem:

Golang 1.12 is out, upstream golang-build-tools has been updated. Bump it here.

