### PR TITLE
Use GOCACHE. It was always being recreated

### DIFF
--- a/build_update.sh
+++ b/build_update.sh
@@ -40,6 +40,7 @@ tar -xf $local_file
 rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
+chown -R u+w build-tools/tests/.gotmp
 rm -rf build-tools/{tests,circle.yml,.circleci,.github,.appveyor.yml,.buildkite,.autotests}
 touch build-tools/build-tools-VERSION-$tag.txt
 git add build-tools

--- a/build_update.sh
+++ b/build_update.sh
@@ -40,7 +40,6 @@ tar -xf $local_file
 rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
-chown -R u+w build-tools/tests/.gotmp
 rm -rf build-tools/{tests,circle.yml,.circleci,.github,.appveyor.yml,.buildkite,.autotests}
 touch build-tools/build-tools-VERSION-$tag.txt
 git add build-tools

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -86,7 +86,7 @@ linux darwin windows: pull $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)"
 	@echo $(shell if [ "$(BUILD_OS)" = "windows" ]; then echo "windows build: BUILD_OS=$(BUILD_OS)  DOCKER_TOOLBOX_INSTALL_PATH=$(DOCKER_TOOLBOX_INSTALL_PATH) PWD=$(PWD) S=$(S)"; fi )
 	@mkdir -p $(GOTMP)/{.cache,pkg,src,bin}
-	$(DOCKERBUILDCMD) \
+	@$(DOCKERBUILDCMD) \
         go install -installsuffix static -ldflags ' $(LDFLAGS) ' $(SRC_AND_UNDER) && touch $@
 	$( shell if [ -d $(GOTMP) ]; then chmod -R u+w $(GOTMP); fi )
 	@echo $(VERSION) >VERSION.txt

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -12,6 +12,7 @@ DOCKERBUILDCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)              
           	    -e CGO_ENABLED=0                  \
           	    -e GOOS=$@						  \
           	    -e GOPATH="//workdir/$(GOTMP)" \
+          	    -e GOCACHE="//workdir/$(GOTMP)/.cache" \
           	    -e GOFLAGS="$(USEMODVENDOR)" \
           	    -w //workdir              \
           	    $(BUILD_IMAGE)
@@ -19,6 +20,7 @@ DOCKERBUILDCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)              
 DOCKERTESTCMD=docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
           	    -v "$(S)$(PWD):/workdir$(DOCKERMOUNTFLAG)"                              \
           	    -e GOPATH="//workdir/$(GOTMP)" \
+          	    -e GOCACHE="//workdir/$(GOTMP)/.cache" \
           	    -e GOFLAGS="$(USEMODVENDOR)" \
           	    -w //workdir              \
           	    $(BUILD_IMAGE)

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -62,11 +62,11 @@ func TestBuild(t *testing.T) {
 	a.NoError(err, "Failed to 'make darwin'")
 	a.Contains(string(v), "building darwin")
 
-	v, err = exec.Command("make", "linux").Output()
-	a.NoError(err)
+	v, err = exec.Command("bash", "-c", "pwd && make linux").Output()
+	a.NoError(err, "failed 'make linux', err=%v, output='%v'", err, string(v))
 	a.Contains(string(v), "building linux")
 
-	v, err = exec.Command("make", "windows").Output()
+	v, err = exec.Command("bash", "-c", "pwd && make windows").Output()
 	a.NoError(err)
 	a.Contains(string(v), "building windows")
 


### PR DESCRIPTION
## The Problem:

GOCACHE is mighty important. Somehow either in the flow of build-tools or the changes in golang caching, we ended up rebuilding the cache on every build.

## The Fix:

Add GOCACHE pointing to workdir/.cache
