### PR TITLE
Bump golang container to v1.12.7

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -34,7 +34,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v1.12.1
+BUILD_IMAGE ?= drud/golang-build-container:v1.12.7
 
 BUILD_BASE_DIR ?= $(PWD)
 


### PR DESCRIPTION
## The Problem:

Time to bump golang build container to v1.12.7

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

