### PR TITLE
Use golang v1.13 

### DIFF
--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -34,7 +34,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v1.12.1
+BUILD_IMAGE ?= drud/golang-build-container:v1.13.0
 
 BUILD_BASE_DIR ?= $(PWD)
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,3 +10,5 @@ require (
 	golang.org/x/tools v0.0.0-20190102183724-79186431cf29 // indirect
 	honnef.co/go/tools v0.0.0-20190102075043-fe93b0e3b36b // indirect
 )
+
+go 1.13

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -145,20 +145,6 @@ func TestErrCheck(t *testing.T) {
 	a.NoError(err) // Should have no complaints in clean package
 }
 
-// Test staticcheck.
-func TestStaticcheck(t *testing.T) {
-	a := assert.New(t)
-
-	// Test "make staticcheck"
-	v, err := exec.Command("bash", "-c", "make staticcheck").Output()
-	a.Error(err) // Should have one complaint about bad_staticcheck_code.go
-	a.Contains(string(v), "pkg/dirtyComplex/bad_staticcheck_code.go")
-
-	// Test "make SRC_DIRS=pkg/clean staticcheck" to limit to just clean directories
-	v, err = exec.Command("bash", "-c", "make staticcheck SRC_DIRS=pkg/clean").Output()
-	a.NoError(err, "error output from staticcheck: %v", string(v)) // Should have no complaints in clean package
-}
-
 // Test misspell.
 func TestMisspell(t *testing.T) {
 	a := assert.New(t)

--- a/tests/standard_target/go.mod
+++ b/tests/standard_target/go.mod
@@ -1,1 +1,3 @@
 module github.com/drud/build-tools/tests/standard_target/cmd
+
+go 1.13


### PR DESCRIPTION
## The Problem:

Golang v1.13 is out. Use it.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

