### PR TITLE
Bump golang to latest and fix build_update.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 version: 2
-stages:
+jobs:
   build:
     machine:
       image: circleci/classic:201711-01

--- a/build_update.sh
+++ b/build_update.sh
@@ -4,11 +4,14 @@
 
 set -e
 
-base_url=$(curl -s -I https://github.com/drud/build-tools/releases/latest | awk '/^Location/ {gsub(/[\n\r]/,"",$2);  printf "%s", $2}')
-tag=${base_url##*/}
+LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/drud/build-tools/releases/latest)
+# The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
+LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+URL="https://github.com/drud/build-tools/releases/download/$LATEST_VERSION"
+tag=${LATEST_VERSION}
 
 tarball_url="https://github.com/drud/build-tools/archive/$tag.tar.gz"
-internal_name=build-tools-$tag
+internal_name=build-tools-${tag#v}
 local_file=/tmp/$internal_name.tgz
 
 # If there is a current build-tools, get permission and remove

--- a/makefile_components/base_build_go.mak
+++ b/makefile_components/base_build_go.mak
@@ -35,7 +35,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v1.14.0
+BUILD_IMAGE ?= drud/golang-build-container:v1.14.2
 
 BUILD_BASE_DIR ?= $(PWD)
 


### PR DESCRIPTION
## The Problem:

Time to bump the golang container.
The build_update.sh script has been broken a long time.

## The Fix:

Bump and fix

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

