### PR TITLE
Update to golang v1.15, remove :delegated, remove docker toolbox support

### DIFF
--- a/.buildkite/windows10dockertoolbox.yml
+++ b/.buildkite/windows10dockertoolbox.yml
@@ -1,7 +1,0 @@
-  - command: ".autotests/test.cmd"
-    agents:
-      - "os=windows"
-      - "dockertype=toolbox"
-    env:
-      BUILDKITE_CLEAN_CHECKOUT: true
-    parallelism: 1

--- a/tests/pkg/clean/build_tools_test.go
+++ b/tests/pkg/clean/build_tools_test.go
@@ -163,9 +163,6 @@ func TestMisspell(t *testing.T) {
 // Test golangci-lint.
 func TestGolangciLint(t *testing.T) {
 	a := assert.New(t)
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping TestGolangciLint on Windows; golangci-lint fails with dockertoolbox, see https://github.com/golangci/golangci-worker/blob/caca2738602c324b1a1d6633ad959aa6d883f2df/app/analyze/executors/temp_dir_shell.go#L27")
-	}
 
 	// Test "make golangci-lint"
 	v, err := exec.Command("bash", "-c", "make golangci-lint").Output()


### PR DESCRIPTION
* Bump to golang v1.15
* Remove docker toolbox testing/support
* Remove :delegated flag from build (it now implies mutagen and makes a mess in macOS)
* Remove extra / on front of things in Windows (this may have to come back)
